### PR TITLE
[REF] Better memory handling in func_consensus()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,12 @@ matrix:
 
 before_install:
     - python -m pip install --upgrade pip
+    - python -m pip install pytest>=3.6
     - if [ "${LINTING}" == "1" ]; then
           pip install flake8;
       fi
     - if [ "${COVERAGE}" == "1" ]; then
-          pip install coverage coveralls codecov pytest pytest-cov;
+          pip install coverage coveralls codecov pytest-cov;
       fi
 
 install:


### PR DESCRIPTION
Previously bootstrapping in func_consensus() was handled...poorly. This
attempts to ~half the amount of memory consumed by only performing
operations on the upper triangle!