### PR TITLE
[ENH] Adds utils.get_centroids() function

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,8 +2,8 @@
 
 .. currentmodule:: netneurotools
 
-Reference API
-=============
+Python Reference API
+====================
 
 .. contents:: **List of modules**
    :local:
@@ -153,3 +153,4 @@ Functions to generate (pseudo-random) datasets
    run
    add_constant
    get_triu
+   get_centroids

--- a/netneurotools/tests/test_datasets.py
+++ b/netneurotools/tests/test_datasets.py
@@ -6,10 +6,10 @@ For testing netneurotools.datasets functionality
 import os
 
 import numpy as np
+import pytest
+
 from netneurotools import datasets
 from netneurotools.datasets import utils
-
-import pytest
 
 
 @pytest.mark.parametrize('corr, size, tol, seed', [
@@ -72,7 +72,9 @@ def test_fetch_cammoun2012(tmpdir, version, expected):
             assert isinstance(out, str) and out.endswith('.nii.gz')
 
 
-@pytest.mark.parametrize('dset', ['atl-cammoun2012', 'tpl-conte69'])
+@pytest.mark.parametrize('dset', [
+    'atl-cammoun2012', 'tpl-conte69'
+])
 def test_get_dataset_info(dset):
     url, md5 = utils._get_dataset_info(dset)
     assert isinstance(url, str) and isinstance(md5, str)

--- a/netneurotools/tests/test_metrics.py
+++ b/netneurotools/tests/test_metrics.py
@@ -4,9 +4,9 @@ For testing netneurotools.metrics functionality
 """
 
 import numpy as np
-from netneurotools import metrics
-
 import pytest
+
+from netneurotools import metrics
 
 rs = np.random.RandomState(1234)
 

--- a/netneurotools/tests/test_modularity.py
+++ b/netneurotools/tests/test_modularity.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+
 from netneurotools import modularity
 
 rs = np.random.RandomState(1234)
 
 
 def test_dummyvar():
+    # generate small example dummy variable code
     out = modularity._dummyvar(np.array([1, 1, 2, 3, 3]))
     assert np.all(out == np.array([[1, 0, 0],
                                    [1, 0, 0],

--- a/netneurotools/tests/test_utils.py
+++ b/netneurotools/tests/test_utils.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+For testing netneurotools.utils functionality
+"""
+
+import numpy as np
+import pytest
+
+from netneurotools import datasets, utils
+
+
+def test_add_constant():
+    # if provided a vector it will return a 2D array
+    assert utils.add_constant(np.random.rand(100)).shape == (100, 2)
+
+    # if provided a 2D array it will return the same, extended by 1 column
+    out = utils.add_constant(np.random.rand(100, 100))
+    assert out.shape == (100, 101) and np.all(out[:, -1] == 1)
+
+
+def test_add_triu():
+    arr = np.arange(9).reshape(3, 3)
+    assert np.all(utils.get_triu(arr) == np.array([1, 2, 5]))
+    assert np.all(utils.get_triu(arr, k=0) == np.array([0, 1, 2, 4, 5, 8]))
+
+
+@pytest.mark.parametrize('scale, expected', [
+    ('scale033', 83),
+    ('scale060', 129),
+    ('scale125', 234),
+    ('scale250', 463),
+    ('scale500', 1015)
+])
+def test_get_centroids(tmpdir, scale, expected):
+    # fetch test dataset
+    cammoun = datasets.fetch_cammoun2012('volume', data_dir=tmpdir, verbose=0)
+
+    ijk = utils.get_centroids(cammoun[scale])
+    xyz = utils.get_centroids(cammoun[scale], image_space=True)
+
+    # we get expected shape regardless of requested coordinate space
+    assert ijk.shape == xyz.shape == (expected, 3)
+    # ijk is all positive (i.e., cartesian) coordinates
+    assert np.all(ijk > 0)
+
+    # requesting specific labels gives us a subset of the full `ijk`
+    lim = utils.get_centroids(cammoun[scale], labels=[1, 2, 3])
+    assert np.all(lim == ijk[:3])

--- a/netneurotools/utils.py
+++ b/netneurotools/utils.py
@@ -72,7 +72,7 @@ def get_triu(data, k=1):
     array([0.5 , 0.25, 0.33])
     """
 
-    return data[np.triu_indices(len(data), k=1)].copy()
+    return data[np.triu_indices(len(data), k=k)].copy()
 
 
 def globpath(*args):
@@ -221,7 +221,8 @@ def get_centroids(img, labels=None, image_space=False):
         3D image containing integer label at each point
     labels : array_like, optional
         List of labels for which to find centroids. If not specified all
-        labels present in `img` will be used. Default: None
+        labels present in `img` will be used. Zero will be ignored as it is
+        considered "background." Default: None
     image_space : bool, optional
         Whether to return xyz (image space) coordinates for centroids based
         on transformation in `img.affine`. Default: False
@@ -236,13 +237,12 @@ def get_centroids(img, labels=None, image_space=False):
     data = img.get_data()
 
     if labels is None:
-        labels = np.unique(data)
+        labels = np.trim_zeros(np.unique(data))
 
-    centroids = ndimage.center_of_mass(data, labels=data, index=labels)
+    centroids = np.row_stack(ndimage.center_of_mass(data, labels=data,
+                                                    index=labels))
 
     if image_space:
         centroids = nib.affines.apply_affine(img.affine, centroids)
-    else:
-        centroids = np.column_stack(centroids)
 
     return centroids


### PR DESCRIPTION
Small wrapper for scipy.ndimage.center_of_mass() to enable easy centroid calculation for neuroimaging atlases.