### PR TITLE
[ENH] Circleplot: heatmaps with circles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ dist: xenial
 notifications:
   email: change
 
+services:
+  - xvfb
+
 python:
   - 3.6
   - 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ dist: xenial
 notifications:
   email: change
 
-services:
-  - xvfb
-
 python:
   - 3.6
   - 3.7
@@ -51,6 +48,7 @@ before_install:
       pip install flake8;
     fi
   - if [ "${CHECK_TYPE}" == "test" ]; then
+      pip install pyqt5;
       pip install "pytest>=3.6" pytest-cov coverage codecov;
     fi
   - if [ ! -z "${INSTALL_NUMBA}"]; then
@@ -83,7 +81,7 @@ script:
       make html;
       make doctest;
     elif [ "${CHECK_TYPE}" == "test" ]; then
-      py.test --doctest-modules --cov-report term-missing --cov=netneurotools netneurotools;
+      pytest --doctest-modules --cov-report term-missing --cov=netneurotools netneurotools;
     else
       false;
     fi

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -88,6 +88,7 @@ Python Reference API
    plot_conte69
    plot_point_brain
    plot_fsaverage
+   circleplot
 
 .. _ref_stats:
 

--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -609,6 +609,8 @@ def circleplot(data, vmin=None, vmax=None, xticklabels=None, yticklabels=None,
         ax.set(xticklabels=xticklabels)
     if yticklabels is not None:
         ax.set(yticklabels=yticklabels[::-1])
-    sns.despine(left=True, bottom=True)
+
+    for side in ['top', 'right', 'left', 'bottom']:
+        ax.spines[side].set_visible(False)
 
     return ax

--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -610,9 +610,9 @@ def circleplot(data, vmin=None, vmax=None, xticklabels=None, yticklabels=None,
     data = np.asarray(data)
 
     if vmin is None:
-        vmin = np.percentile(data, 2)
+        vmin = data.dtype.type(np.percentile(data, 2))
     if vmax is None:
-        vmax = np.percentile(data, 98)
+        vmax = data.dtype.type(np.percentile(data, 98))
 
     # size must be bounded by vmin and vmax so it is comparable across graphs
     size = data.copy()

--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -570,3 +570,45 @@ def plot_point_brain(data, coords, views=None, cbar=False, figsize=(4, 4.8),
         cbar.outline.set_linewidth(0)
 
     return fig
+
+
+def circleplot(data, vmin=None, vmax=None, xticklabels=None, yticklabels=None,
+               cmap='rocket', cbar=True, ax=None, cbar_kws=None):
+    """
+    """
+
+    data = np.asarray(data)
+
+    if vmin is None:
+        vmin = np.percentile(data, 2)
+    if vmax is None:
+        vmax = np.percentile(data, 98)
+
+    # size must be bounded by vmin and vmax so it is comparable across graphs
+    size = data.copy()
+    size[size < vmin] = vmin
+    size[size > vmax] = vmax
+    rescaled = np.ravel((size - vmin) / (vmax - vmin)) + 1.0001
+    if vmin < 0:  # cannot be negative
+        rescaled += np.abs(vmin)
+
+    if ax is None:
+        ax = plt.gca()
+
+    x = np.tile(np.linspace(0, 1, len(data.T)), len(data.T))
+    y = np.repeat(np.linspace(1, 0, len(data)), len(data))
+    coll = ax.scatter(x, y, s=np.log(rescaled) * 1500, c=np.ravel(data),
+                      cmap=cmap, vmin=vmin, vmax=vmax)
+    ax.set(xlim=(-0.1, 1.1), ylim=(-0.1, 1.1), xticks=x, yticks=x)
+    if cbar:
+        if cbar_kws is None:
+            cbar_kws = {}
+        cbar = plt.colorbar(coll, ax=ax, **cbar_kws)
+        cbar.outline.set_linewidth(0)
+    if xticklabels is not None:
+        ax.set(xticklabels=xticklabels)
+    if yticklabels is not None:
+        ax.set(yticklabels=yticklabels[::-1])
+    sns.despine(left=True, bottom=True)
+
+    return ax

--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -573,8 +573,38 @@ def plot_point_brain(data, coords, views=None, cbar=False, figsize=(4, 4.8),
 
 
 def circleplot(data, vmin=None, vmax=None, xticklabels=None, yticklabels=None,
-               cmap='rocket', cbar=True, ax=None, cbar_kws=None):
+               cmap='viridis', cbar=True, ax=None, cbar_kws=None):
     """
+    Plots `data` as a heatmap but with circles whose size scale with value
+
+    Parameters
+    ----------
+    data : (N, M) array_like
+        Data for an `N` node parcellation; determines color of points
+    vmin : float, optional
+        Minimum value for colorbar. If not provided, a robust estimation will
+        be used from values in `data`. Default: None
+    vmax : float, optional
+        Maximum value for colorbar. If not provided, a robust estimation will
+        be used from values in `data`. Default: None
+    {x,y}ticklabels : list, optional
+        Labels for {x,y} ticks. If not specified will use defaults of
+        :func:`maplotlib.pyplot.scatter`. Default: None
+    cmap : str, optional
+        Which colormap to use for plotting the data. Default: 'viridis'
+    cbar : bool, optional
+        Whether to display the colorbar. Default: True
+    ax : matplotlib.axes.Axes, optional
+        Axis on which to plot the heatmap. If none provided, the current axis
+        will be used. Default: None
+    cbar_kws : dict, optional
+        Passed to :func:`matplotlib.pyplot.colorbar` during creation of
+        colorbar. Only used if `cbar=True`. Default: None
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        Axis object containing plot
     """
 
     data = np.asarray(data)

--- a/netneurotools/tests/test_plotting.py
+++ b/netneurotools/tests/test_plotting.py
@@ -3,15 +3,15 @@
 For testing netneurotools.plotting functionality
 """
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
 from netneurotools import plotting
 
-rs = np.random.RandomState(1234)
-
 
 def test_circleplot():
-    data = rs.random.rand(10, 10)
+    data = np.arange(100).reshape(10, 10) + 1
     fig, ax = plt.subplots(1, 1)
-    plotting.circleplot(data, ax=ax)
+    ax = plotting.circleplot(data, ax=ax)
+    assert isinstance(ax, mpl.axes.Axes)

--- a/netneurotools/tests/test_plotting.py
+++ b/netneurotools/tests/test_plotting.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""
+For testing netneurotools.plotting functionality
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from netneurotools import plotting
+
+rs = np.random.RandomState(1234)
+
+
+def test_circleplot():
+    data = rs.random.rand(10, 10)
+    fig, ax = plt.subplots(1, 1)
+    plotting.circleplot(data, ax=ax)

--- a/netneurotools/tests/test_plotting.py
+++ b/netneurotools/tests/test_plotting.py
@@ -6,12 +6,20 @@ For testing netneurotools.plotting functionality
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 
 from netneurotools import plotting
 
 
-def test_circleplot():
-    data = np.arange(100).reshape(10, 10) + 1
+@pytest.mark.parametrize('kwargs', [
+    dict(vmin=10, vmax=90),
+    dict(robust=True),
+    dict(xticklabels=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']),
+    dict(cmap='RdBu', cbar=False),
+    dict(cbar_kws=dict(ticks=[0, 1]))
+])
+def test_circleplot(kwargs):
+    data = np.arange(100).reshape(10, 10)
     fig, ax = plt.subplots(1, 1)
-    ax = plotting.circleplot(data, ax=ax)
+    ax = plotting.circleplot(data, ax=ax, **kwargs)
     assert isinstance(ax, mpl.axes.Axes)


### PR DESCRIPTION
Adds the function `netneurotools.plotting.circleplot()`, which basically amounts to a heatmap with circles where the size of the circles is scaled by their value. It _sounds_ redundant because it is, but sometimes it's nice to visually reduce the cells in a heatmap with low values.

The function makes a call to `matplotlib.pyplot.scatter()` under the hood, but exposes a few additional keyword arguments to make things easier.

**To do**:
- [ ] Improve scaling of circle size based on provided values. Currently the function rescales the data values before plotting, but this is not particularly robust
- [ ] Add tests for different parameters / functionality