### PR TITLE
[REF] Fixes Cammoun et al., 2012 Freesurfer files

### DIFF
--- a/netneurotools/datasets/datasets.py
+++ b/netneurotools/datasets/datasets.py
@@ -69,7 +69,7 @@ def fetch_cammoun2012(version='volume', data_dir=None, url=None, resume=True,
     keys = ['scale033', 'scale060', 'scale125', 'scale250', 'scale500']
 
     data_dir = _get_data_dir(data_dir=data_dir)
-    info = _get_dataset_info(dataset_name)
+    info = _get_dataset_info(dataset_name)[version]
     if url is None:
         url = info['url']
 

--- a/netneurotools/datasets/utils.py
+++ b/netneurotools/datasets/utils.py
@@ -8,8 +8,18 @@ import os
 OSF_API = "https://files.osf.io/v1/resources/{}/providers/osfstorage/{}"
 OSF_RESOURCES = {
     'atl-cammoun2012': {
-        'url': OSF_API.format('mb37e', '5c59c82576653c001b27d7e4'),
-        'md5': '68ea0c7e3de7fbd0fd92220efd02d73e'
+        'gcs': {
+            'url': OSF_API.format('mb37e', '5ce6bb4423fec40017e82c5e'),
+            'md5': 'c3435f2720da6a74c3d55db54ebdbfff'
+        },
+        'surface': {
+            'url': OSF_API.format('mb37e', '5ce6c30523fec40017e83439'),
+            'md5': '478599b362a88198396fdb15ad999f9e'
+        },
+        'volume': {
+            'url': OSF_API.format('mb37e', '5ce6bb438d6e05001860abca'),
+            'md5': 'b0b6ced54b7b86d150fc7461dec72639'
+        }
     },
     'atl-pauli2018': [
         {

--- a/netneurotools/freesurfer.py
+++ b/netneurotools/freesurfer.py
@@ -2,13 +2,11 @@
 """
 Functions for working with FreeSurfer data and parcellations
 """
+
 import os
 import os.path as op
-import shutil
 
-import nibabel as nib
 import numpy as np
-import pandas as pd
 from scipy.spatial.distance import cdist
 
 from .datasets import fetch_fsaverage
@@ -57,7 +55,8 @@ def apply_prob_atlas(subject_id, gcs, hemi, *, orig='white', annot=None,
         Path to generated annotation file
     """
 
-    cmd = 'mris_ca_label {opts}{subject_id} {hemi} {hemi}.sphere.reg {gcs} {annot}' # noqa
+    cmd = 'mris_ca_label {opts}{subject_id} {hemi} {hemi}.sphere.reg ' \
+          '{gcs} {annot}'
 
     if hemi not in ['rh', 'lh']:
         raise ValueError('Provided hemisphere designation `hemi` must be one '
@@ -96,121 +95,18 @@ def apply_prob_atlas(subject_id, gcs, hemi, *, orig='white', annot=None,
     return annot
 
 
-def combine_cammoun_500(files, subject_id, subjects_dir=None,
-                        use_cache=True, quiet=False):
-    """
-    Combines finest parcellation from Cammoun et al., 2012 for `subject_id`
-
-    The parcellations from Cammoun et al., 2012 have five distinct scales; the
-    highest resolution parcellation (scale 500) is split into three GCS files
-    for historical FreeSurfer purposes. This is a bit annoying for calculating
-    statistics, plotting, etc., so this function can be run once all the GCS
-    files have been used to produce annotations files for `subject_id` (using
-    :py:func:`netneurotools.freesurfer.apply_parcellation`). This function will
-    combine the three annot files that correspond to the highest resolution
-    into a single annot file for a given subject
-
-    Parameters
-    ----------
-    files : list of str
-        List of filepaths to Cammoun et al., 2012 scale 500 parcellation
-    subject_id : str
-        FreeSurfer subject ID
-    subjects_dir : str, optional
-        Path to FreeSurfer subject directory. If not set, will inherit from
-        the environmental variable `$SUBJECTS_DIR`. Default: None
-    use_cache : bool, optional
-        Whether to check for existence of relevant statistics file in directory
-        specified by `{subjects_dir}/{subject_id}/stats' and use, if it exists.
-        If False, will create a new stats file. Default: True
-    quiet : bool, optional
-        Whether to restrict status messages. Default: False
-
-    Returns
-    -------
-    cammoun500 : list
-        List of created annotation files
-    """
-
-    tolabel = 'mri_annotation2label --subject {subject_id} --hemi {hemi} --outdir {label_dir} --annotation {annot} --sd {subjects_dir}'  # noqa
-    toannot = 'mris_label2annot --sd {subjects_dir} --s {subject_id} --ldir {label_dir} --hemi {hemi} --annot-path {annot} --ctab {ctab} {label}'  # noqa
-
-    gcs_files = ['{hemi}' + f[3:] for f in files if f.startswith('rh')]
-    subject_id, subjects_dir = check_fs_subjid(subject_id, subjects_dir)
-
-    created = []
-    for hemi in ['R', 'L']:
-        # don't overwrite annotation file if it's already been created
-        cammoun500 = os.path.join(subjects_dir, subject_id, 'label',
-                                  '{}.cammoun500.annot'.format(hemi))
-        if os.path.isfile(cammoun500) and use_cache:
-            created.append(cammoun500)
-            continue
-
-        # make directory to temporarily store labels
-        label_dir = os.path.join(subjects_dir, subject_id,
-                                 '{}.cammoun500.labels'.format(hemi))
-        os.makedirs(label_dir, exist_ok=True)
-
-        ctab = pd.DataFrame(columns=range(5))
-        for gcs in gcs_files:
-            # grab relevant annotation file and convert to labels
-            annot = apply_prob_atlas(subject_id, gcs.format(hemi=hemi),
-                                     hemi=hemi, subjects_dir=subjects_dir)
-            run(tolabel.format(subject_id=subject_id, hemi=hemi,
-                               label_dir=label_dir, annot=annot,
-                               subjects_dir=subjects_dir),
-                quiet=quiet)
-
-            # save ctab information from annotation file
-            vtx, ct, names = nib.freesurfer.read_annot(annot)
-            data = np.column_stack([[f.decode() for f in names], ct[:, :-1]])
-            ctab = ctab.append(pd.DataFrame(data), ignore_index=True)
-
-        # get rid of duplicate entries and add back in unknown/corpuscallosum
-        ctab = ctab.drop_duplicates(subset=[0], keep=False)
-        add_back = pd.DataFrame([['unknown', 25, 5, 25, 0],
-                                 ['corpuscallosum', 120, 70, 50, 0]],
-                                index=[0, 4])
-        ctab = ctab.append(add_back).sort_index().reset_index(drop=True)
-        # save ctab to temporary file for creation of annotation file
-        ctab_fname = os.path.join(label_dir, '{}.cammoun500.ctab'.format(hemi))
-        ctab.to_csv(ctab_fname, header=False, sep='\t', index=True)
-
-        # get all labels EXCEPT FOR UNKNOWN to combine into annotation
-        # unknown will be regenerated as all the unmapped vertices
-        label = ' '.join(['--l {}'
-                         .format(os.path.join(label_dir,
-                                              '{hemi}.{lab}.label'
-                                              .format(hemi=hemi, lab=lab)))
-                          for lab in ctab.iloc[1:, 0]])
-        # combine labels into annotation file
-        run(toannot.format(subjects_dir=subjects_dir, subject_id=subject_id,
-                           label_dir=label_dir, hemi=hemi, ctab=ctab_fname,
-                           annot=cammoun500, label=label),
-            quiet=quiet)
-        created.append(cammoun500)
-
-        # remove temporary label directory
-        shutil.rmtree(label_dir)
-
-    return created
-
-
 def find_fsaverage_centroids(lhannot, rhannot, surf='sphere'):
     """
     Finds vertices corresponding to centroids of parcels in annotation files
 
-    Note that using anything other than `surf=sphere` may result in centroids
-    that are not directly within the parcels themselves due to sulcal folding.
+    Note that using any other `surf` besides the default of 'sphere' may result
+    in centroids that are not directly within the parcels themselves due to
+    sulcal folding patterns.
 
     Parameters
     ----------
-    lhannot : str
-        Filepath to .annot file containing labels to parcels on the left
-        hemisphere
-    rhannot : str
-        Filepath to .annot file containing labels to parcels on the right
+    {lh,rh}annot : str
+        Path to .annot file containing labels to parcels on the {left,right}
         hemisphere
     surf : str, optional
         Surface on which to find parcel centroids. Default: 'sphere'
@@ -224,6 +120,8 @@ def find_fsaverage_centroids(lhannot, rhannot, surf='sphere'):
         Array denoting hemisphere designation of coordinates in `centroids`,
         where `hemiid=0` denotes the left and `hemiid=1` the right hemisphere
     """
+
+    import nibabel as nib
 
     surfaces = fetch_fsaverage()[surf]
 

--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -9,14 +9,8 @@ from typing import Iterable
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # noqa
-import nibabel as nib
 import numpy as np
 from scipy.stats import zscore
-import seaborn as sns
-
-from .datasets import fetch_conte69, fetch_fsaverage
-from .datasets.utils import _get_data_dir
-from .utils import check_fs_subjid
 
 
 def _grid_communities(communities):
@@ -114,6 +108,8 @@ def plot_mod_heatmap(data, communities, *, inds=None, edgecolor='black',
     ax : matplotlib.axes.Axes
         Axis object containing plot
     """
+
+    import seaborn as sns
 
     # get indices for sorting consensus
     if inds is None:
@@ -225,6 +221,8 @@ def plot_conte69(data, lhlabel, rhlabel, surf='midthickness',
         Scene object containing plot
     """
 
+    import nibabel as nib
+    from .datasets import fetch_conte69
     try:
         from mayavi import mlab
     except ImportError:
@@ -340,6 +338,8 @@ def plot_fsaverage(data, lhannot, rhannot, *, surf='pial', views='lat',
     """
 
     # hold off on imports until
+    import nibabel as nib
+    from .utils import check_fs_subjid
     try:
         from surfer import Brain
     except ImportError:
@@ -350,6 +350,8 @@ def plot_fsaverage(data, lhannot, rhannot, *, surf='pial', views='lat',
     try:
         subject_id, subjects_dir = check_fs_subjid('fsaverage', subjects_dir)
     except FileNotFoundError:
+        from .datasets import fetch_fsaverage
+        from .datasets.utils import _get_data_dir
         fetch_fsaverage()
         subjects_dir = _get_data_dir()
         subject_id, subjects_dir = check_fs_subjid('fsaverage', subjects_dir)
@@ -395,9 +397,11 @@ def plot_fsaverage(data, lhannot, rhannot, *, surf='pial', views='lat',
         # do, so we need to account for that
         # find the label ids that correspond to those and set them to NaN in
         # the `data vector`
-        inds = [n for n, f in enumerate(names) if f in drop]
-        fulldata = np.insert(hemidata, inds - np.arange(len(inds)), np.nan)
-        vtx_data = fulldata[labels]
+        inds = [names.index(n) for n in drop]
+        for i in inds:
+            hemidata = np.insert(hemidata, i, np.nan)
+        # fulldata = np.insert(hemidata, inds - np.arange(len(inds)), np.nan)
+        vtx_data = hemidata[labels]
         not_nan = ~np.isnan(vtx_data)
 
         # we don't want the NaN vertices (unknown / corpuscallosum) plotted

--- a/netneurotools/tests/test_datasets.py
+++ b/netneurotools/tests/test_datasets.py
@@ -88,7 +88,7 @@ def test_fetch_cammoun2012(tmpdir, version, expected):
 
 
 @pytest.mark.parametrize('dset, expected', [
-    ('atl-cammoun2012', ['url', 'md5']),
+    ('atl-cammoun2012', ['volume', 'surface', 'gcs']),
     ('tpl-conte69', ['url', 'md5']),
     ('atl-pauli2018', ['url', 'md5', 'name']),
     ('tpl-fsaverage', ['url', 'md5'])

--- a/resources/generate_atl-cammoun2012_surface.py
+++ b/resources/generate_atl-cammoun2012_surface.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+"""
+This script was used to generate the FreeSurfer-style surface annotation files
+for the Cammoun et al., 2012 parcellation provided via `netneurotools`.
+
+That is, the files returned with:
+
+    >>> netneurotools.datasets.fetch_cammoun2012('surface')
+
+were created with this script.
+"""
+
+import glob
+import os
+import os.path as op
+import re
+import shutil
+
+from netneurotools import datasets, freesurfer
+import nibabel as nib
+import numpy as np
+import pandas as pd
+
+
+def combine_cammoun_500(lhannot, rhannot, subject_id, annot=None,
+                        subjects_dir=None, use_cache=True, quiet=False):
+    """
+    Combines finest parcellation from Cammoun et al., 2012 for `subject_id`
+
+    The parcellations from Cammoun et al., 2012 have five distinct scales; the
+    highest resolution parcellation (scale 500) is split into three GCS files
+    for historical FreeSurfer purposes. This is a bit annoying for calculating
+    statistics, plotting, etc., so this function can be run once all the GCS
+    files have been used to produce annotations files for `subject_id` (using
+    :py:func:`netneurotools.freesurfer.apply_prob_atlas`). This function will
+    combine the three .annot files that correspond to the highest resolution
+    into a single .annot file for a given subject
+
+    Parameters
+    ----------
+    {lh,rh}files : (3,) list of str
+        List of filepaths to {left, right} hemisphere annotation files for
+        Cammoun et al., 2012 scale500 parcellation
+    subject_id : str
+        FreeSurfer subject ID
+    annot : str, optional
+        Path to output annotation file to generate. If set to None, the name is
+        created from the provided `?hannot` files. If provided as a relative
+        path, it is assumed to stem from `subjects_dir`/`subject_id`. Default:
+        None
+    subjects_dir : str, optional
+        Path to FreeSurfer subject directory. If not set, will inherit from
+        the environmental variable `$SUBJECTS_DIR`. Default: None
+    use_cache : bool, optional
+        Whether to check for existence of relevant statistics file in directory
+        specified by `{subjects_dir}/{subject_id}/stats' and use, if it exists.
+        If False, will create a new stats file. Default: True
+    quiet : bool, optional
+        Whether to restrict status messages. Default: False
+
+    Returns
+    -------
+    cammoun500 : list
+        List of created annotation files
+    """
+    from netneurotools.utils import check_fs_subjid, run
+
+    tolabel = 'mri_annotation2label --subject {subject_id} --hemi {hemi} ' \
+              '--outdir {label_dir} --annotation {annot} --sd {subjects_dir}'
+    toannot = 'mris_label2annot --sd {subjects_dir} --s {subject_id} ' \
+              '--ldir {label_dir} --hemi {hemi} --annot-path {annot} ' \
+              '--ctab {ctab} {label}'
+
+    subject_id, subjects_dir = check_fs_subjid(subject_id, subjects_dir)
+
+    created = []
+    for hemi, annotfiles in zip(['lh', 'rh'], [lhannot, rhannot]):
+        # generate output name based on hemisphere
+        out = annot.format(hemi[0].upper())
+        if not out.startswith(os.path.abspath(os.sep)):
+            out = os.path.join(subjects_dir, subject_id, 'label', out)
+
+        if os.path.isfile(out) and use_cache:
+            created.append(out)
+            continue
+
+        # make directory to temporarily store labels
+        label_dir = os.path.join(subjects_dir, subject_id,
+                                 '{}.cammoun500.labels'.format(hemi))
+        os.makedirs(label_dir, exist_ok=True)
+
+        ctab = pd.DataFrame(columns=range(5))
+        for fn in annotfiles:
+            run(tolabel.format(subject_id=subject_id, hemi=hemi,
+                               label_dir=label_dir, annot=fn,
+                               subjects_dir=subjects_dir),
+                quiet=quiet)
+
+            # save ctab information from annotation file
+            vtx, ct, names = nib.freesurfer.read_annot(fn)
+            data = np.column_stack([[f.decode() for f in names], ct[:, :-1]])
+            ctab = ctab.append(pd.DataFrame(data), ignore_index=True)
+
+        # get rid of duplicate entries and add back in unknown/corpuscallosum
+        ctab = ctab.drop_duplicates(subset=[0], keep=False)
+        add_back = pd.DataFrame([['unknown', 25, 5, 25, 0],
+                                 ['corpuscallosum', 120, 70, 50, 0]],
+                                index=[0, 4])
+        ctab = ctab.append(add_back).sort_index().reset_index(drop=True)
+        # save ctab to temporary file for creation of annotation file
+        ctab_fname = os.path.join(label_dir, '{}.cammoun500.ctab'.format(hemi))
+        ctab.to_csv(ctab_fname, header=False, sep='\t', index=True)
+
+        # get all labels EXCEPT FOR UNKNOWN to combine into annotation
+        # unknown will be regenerated as all the unmapped vertices
+        label = ' '.join(['--l {}'
+                         .format(os.path.join(label_dir,
+                                              '{hemi}.{lab}.label'
+                                              .format(hemi=hemi, lab=lab)))
+                          for lab in ctab.iloc[1:, 0]])
+        # combine labels into annotation file
+        run(toannot.format(subjects_dir=subjects_dir, subject_id=subject_id,
+                           label_dir=label_dir, hemi=hemi, ctab=ctab_fname,
+                           annot=out, label=label),
+            quiet=quiet)
+        created.append(out)
+
+        # remove temporary label directory
+        shutil.rmtree(label_dir)
+
+    return created
+
+
+def strip(x):
+    """ Removes everything after last underscore from `x` """
+    return '_'.join(x.split('_')[:-1])
+
+
+annot = 'atl-Cammoun2012_space-fsaverage_res-{}_hemi-{}_deterministic.annot'
+
+
+if __name__ == '__main__':
+    #####
+    # get the GCS files and apply them onto the fsaverage surface
+    gcs = datasets.fetch_cammoun2012('gcs')
+    for scale, gcsfiles in gcs.items():
+        for fn in gcsfiles:
+            hemi = re.search('hemi-([RL])', fn).group(1)
+            scale = re.search('res-(.*)_hemi-', fn).group(1)
+            out = op.join(op.dirname(fn), annot.format(scale, hemi))
+            freesurfer.apply_prob_atlas('fsaverage', fn, hemi.lower() + 'h',
+                                        ctab=fn.replace('.gcs', '.ctab'),
+                                        annot=out)
+
+    #####
+    # get scale 500 parcellation files and combine
+    dirname = op.dirname(fn)
+    lh = sorted(glob.glob(op.join(dirname, '*res-500*_hemi-L*annot')))
+    rh = sorted(glob.glob(op.join(dirname, '*res-500*_hemi-R*annot')))
+    annot = op.join(dirname, annot.format('500', '{}'))
+    parc500 = combine_cammoun_500(lh, rh, 'fsaverage', annot=annot)
+    for fn in lh + rh:
+        os.remove(fn)
+
+    #####
+    # map all the WRONG .annot files to the correct ordering
+    info = pd.read_csv(datasets.fetch_cammoun2012('volume')['info'])
+    for scale in ['033', '060', '125', '250', '500']:
+        annots = sorted(glob.glob(op.join(dirname, f'*res-{scale}*annot')))
+        scinfo = info.query(f'scale == "scale{scale}" & structure == "cortex"')
+        scinfo = scinfo.groupby('hemisphere')
+        scinfo = [scinfo.get_group(m) for m in scinfo.groups]
+        for annot, hemi in zip(annots, scinfo):
+            labels, ctab, names = nib.freesurfer.read_annot(annot)
+            ulab = np.unique(labels)
+            idx = [names.index(n) for n in [b'unknown', b'corpuscallosum']]
+            names = [n.decode() for n in names]
+            ids = list(hemi['id'])
+            targets = list(hemi['label'].apply(strip))
+            inds = [names.index(x) for x in targets]
+            for i in idx:
+                inds = np.insert(inds, i, i)
+            names = [n.encode() for n in np.array(names)[inds]]
+            ctab = ctab[inds]
+            src, tar = np.array(inds), np.arange(len(names))
+            sidx = src.argsort()
+            src, tar = src[sidx], tar[sidx]
+            labels = tar[np.searchsorted(src, labels)]
+            nib.freesurfer.write_annot(annot, labels, ctab, names)


### PR DESCRIPTION
Previous surface .annot files for the Cammoun 2012 parcellation were out-of-sync with the volumetric images. This fixes them and addresses a whole bunch of other changes that were resolved in the processing of that fix.