### PR TITLE
[REF] Reduces memory consumption in Mirchi et al., 2018 example

### DIFF
--- a/netneurotools/info.py
+++ b/netneurotools/info.py
@@ -7,8 +7,10 @@ __credits__ = [
     'Justine Hansen',
     'Zhen-Qi Liu',
     'Ross Markello',
-    'Bratislav Misic',
+    'Bratislav Mišić',
     'Golia Shafiei',
+    'Estefany Suárez',
+    'Bertha Vázquez-Rodríguez'
 ]
 __license__ = 'BSD-3'
 __maintainer__ = 'Network Neuroscience Lab'


### PR DESCRIPTION
Or at least, tries to reduce memory consumption... It was causing the ReadTheDocs build to fail because of excessive memory usage, so this deletes some large intermediate arrays that might help keep the load low.