### PR TITLE
[REF] Updates gen_spinsamples for efficiency

### DIFF
--- a/examples/plot_spin_test.py
+++ b/examples/plot_spin_test.py
@@ -3,9 +3,12 @@
 Spin-tests for significance testing
 ===================================
 
-This example shows how to perform "spin-tests" (Alexander-Bloch et al., 2018)
-to assess whether two brain patterns are correlated above and beyond what would
-be expected from spatially-autocorrelated null models.
+This example shows how to perform "spin-tests" (a la Alexander-Bloch et al.,
+2018, NeuroImage) to assess whether two brain patterns are correlated above and
+beyond what would be expected from a spatially-autocorrelated null model.
+
+For the original MATLAB toolbox published alongside the paper by
+Alexander-Bloch and colleagues refer to https://github.com/spin-test/spin-test.
 """
 
 ###############################################################################

--- a/netneurotools/stats.py
+++ b/netneurotools/stats.py
@@ -397,7 +397,8 @@ def gen_spinsamples(coords, hemiid, n_rotate=1000, check_duplicates=True,
     once and exactly once in the resampling), you can set the ``exact``
     parameter to True:
 
-        >>> nnstats.gen_spinsamples(coords, hemi, n_rotate=1, exact=True, seed=1)[0]
+        >>> nnstats.gen_spinsamples(coords, hemi, n_rotate=1, seed=1,
+        ...                         exact=True)[0]
         array([[1],
                [0],
                [2],

--- a/netneurotools/stats.py
+++ b/netneurotools/stats.py
@@ -398,6 +398,9 @@ def gen_spinsamples(coords, hemiid, n_rotate=1000, check_duplicates=True,
 
     seed = check_random_state(seed)
 
+    coords = np.asanyarray(coords)
+    hemiid = np.asanyarray(hemiid).astype(int)
+
     # check supplied coordinate shape
     if coords.shape[-1] != 3 or coords.squeeze().ndim != 2:
         raise ValueError('Provided `coords` must be of shape (N, 3), not {}'
@@ -414,7 +417,7 @@ def gen_spinsamples(coords, hemiid, n_rotate=1000, check_duplicates=True,
     if np.max(hemiid) != 1 or np.min(hemiid) != 0:
         raise ValueError('Hemiid must have values in {0, 1} denoting left and '
                          'right hemisphere coordinates, respectively. '
-                         'Provided array contains values: {}'
+                         + 'Provided array contains values: {}'
                          .format(np.unique(hemiid)))
 
     # empty array to store resampling indices

--- a/netneurotools/stats.py
+++ b/netneurotools/stats.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 from scipy import optimize
 from scipy.spatial.distance import cdist
+from scipy.spatial import cKDTree
 from scipy.stats import zmap
 from scipy.stats.stats import _chk_asarray, _chk2_asarray
 from sklearn.utils.validation import check_random_state
@@ -327,13 +328,22 @@ def _gen_rotation(seed=None):
     return rotate_l, rotate_r
 
 
-def gen_spinsamples(coords, hemiid, exact=False, n_rotate=1000, seed=None):
+def gen_spinsamples(coords, hemiid, n_rotate=1000, check_duplicates=True,
+                    exact=False, seed=None):
     """
-    Generates resampling array for `coords` via rotational spins
+    Returns a resampling array for `coords` obtained from rotations / spins
 
-    Using the method initially proposed in [ST1]_ (and later modified / updated
-    based on findings in [ST2]_ and [ST3]_), this function can be used to
-    generate a resampling array for conducting spatial permutation tests.
+    Using the method initially proposed in [ST1]_ (and later modified + updated
+    based on findings in [ST2]_ and [ST3]_), this function applies random
+    rotations to the user-supplied `coords` in order to generate a resampling
+    array that preserves its spatial embedding. Rotations are generated for one
+    hemisphere and mirrored for the other (see `hemiid` for more information).
+
+    Due to irregular sampling of `coords` and the randomness of the rotations
+    it is possible that some "rotations" may resample with replacement (i.e.,
+    will not be a true permutation). The likelihood of this can be reduced by
+    either increasing the sampling density of `coords` or setting the ``exact``
+    parameter to True (though see Notes for more information on the latter).
 
     Parameters
     ----------
@@ -342,13 +352,19 @@ def gen_spinsamples(coords, hemiid, exact=False, n_rotate=1000, seed=None):
         sphere
     hemiid : (N,) array_like
         Array denoting hemisphere designation of coordinates in `coords`, where
-        `hemiid=0` denotes the left and `hemiid=1` the right hemisphere
-    exact : bool, optional
-        Whether each node/parcel/region must be uniquely re-assigned in every
-        rotation. Setting to True will drastically increase the runtime of this
-        function! Default: False
+        values should be {0, 1} denoting the different hemispheres. Rotations
+        are generated for one hemisphere and mirrored across the y-axis for the
+        other hemisphere.
     n_rotate : int, optional
-        Number of random rotations to generate. Default: 1000
+        Number of rotations to generate. Default: 1000
+    check_duplicates : bool, optional
+        Whether to check for and attempt to avoid duplicate resamplings. A
+        warnings will be raised if duplicates cannot be avoided. Setting to
+        True may increase the runtime of this function! Default: True
+    exact : bool, optional
+        Whether each node/parcel/region should be uniquely re-assigned in every
+        rotation. Setting to True will drastically increase the memory demands
+        and runtime of this function! Default: False
     seed : {int, np.random.RandomState instance, None}, optional
         Seed for random number generation. Default: None
 
@@ -359,6 +375,10 @@ def gen_spinsamples(coords, hemiid, exact=False, n_rotate=1000, seed=None):
     cost : (`n_rotate`,) numpy.ndarray
         Cost (in distance between node assignments) of each rotation in
         `spinsamples`
+
+    Notes
+    -----
+    The ``exact`` parameter controls
 
     References
     ----------
@@ -391,18 +411,21 @@ def gen_spinsamples(coords, hemiid, exact=False, n_rotate=1000, seed=None):
         raise ValueError('Provided `coords` and `hemiid` must have the same '
                          'length. Provided lengths: coords = {}, hemiid = {}'
                          .format(len(coords), len(hemiid)))
-    if not np.allclose(np.unique(hemiid), [0, 1]):
-        raise ValueError('Hemiid must have values of [0, 1] denoting left '
-                         'and right hemisphere coordinates, respectively. '
+    if np.max(hemiid) != 1 or np.min(hemiid) != 0:
+        raise ValueError('Hemiid must have values in {0, 1} denoting left and '
+                         'right hemisphere coordinates, respectively. '
                          'Provided array contains values: {}'
                          .format(np.unique(hemiid)))
 
     # empty array to store resampling indices
-    spinsamples = np.zeros((len(coords), n_rotate), dtype=int)
+    # int32 should be enough; if you're ever providing `coords` with more than
+    # 2147483647 rows please reconsider your life choices
+    spinsamples = np.zeros((len(coords), n_rotate), dtype='int32')
     cost = np.zeros(n_rotate)
 
     # split coordinates into left / right hemispheres
-    inds_l, inds_r = np.where(hemiid == 0)[0], np.where(hemiid == 1)[0]
+    inds = np.arange(len(coords))
+    inds_l, inds_r = hemiid == 0, hemiid == 1
     coords_l, coords_r = coords[inds_l], coords[inds_r]
 
     # generate rotations and resampling array!
@@ -412,49 +435,51 @@ def gen_spinsamples(coords, hemiid, exact=False, n_rotate=1000, seed=None):
         count, duplicated = 0, True
         while duplicated and count < 500:
             count, duplicated = count + 1, False
-            resampled = np.zeros(len(coords), dtype=int)
+            resampled = np.zeros(len(coords), dtype='int32')
 
             # generate left + right hemisphere rotations
             left, right = _gen_rotation(seed=seed)
 
-            # calculate Euclidean distance between original and rotated coords
-            dist_l = cdist(coords_l, coords_l @ left)
-            dist_r = cdist(coords_r, coords_r @ right)
-
             # find mapping of rotated coords to original coords
-            # if we need an exact mapping (i.e., every node needs a unique
-            # assignment in the rotation) then we need to use an optimization
-            # procedure (i.e., the Hungarian algorithm)
             if exact:
+                # if we need an exact mapping (i.e., every node needs a unique
+                # assignment in the rotation) then we need to use an
+                # optimization procedure
+                #
+                # this requires calculating the FULL distance matrix, which is
+                # a nightmare with respect to memory (and frequently fails due
+                # to insufficient memory)
+                dist_l = cdist(coords_l, coords_l @ left)
+                dist_r = cdist(coords_r, coords_r @ right)
                 lrow, lcol = optimize.linear_sum_assignment(dist_l)
                 rrow, rcol = optimize.linear_sum_assignment(dist_r)
-            # otherwise, if nodes can be assigned multiple targets, we can just
-            # use the absolute minimum of the distances.
+                ccost = dist_l[lrow, lcol].sum() + dist_r[rrow, rcol].sum()
             else:
-                lrow, lcol = range(len(dist_l)), dist_l.argmin(axis=1)
-                rrow, rcol = range(len(dist_r)), dist_r.argmin(axis=1)
+                # if nodes can be assigned multiple targets, we can simply use
+                # the absolute minimum of the distances (no optimization
+                # required) which is _much_ lighter on memory
+                # huge thanks to: https://stackoverflow.com/a/47779290
+                dist_l, lcol = cKDTree(coords_l @ left).query(coords_l, 1)
+                dist_r, rcol = cKDTree(coords_r @ right).query(coords_r, 1)
+                ccost = dist_l.sum() + dist_r.sum()
 
             # generate resampling vector
-            resampled[inds_l] = inds_l[lcol]
-            resampled[inds_r] = inds_r[rcol]
+            resampled[inds_l] = inds[inds_l][lcol]
+            resampled[inds_r] = inds[inds_r][rcol]
 
-            # check whether this is a duplicate resampling; if so, try again
-            dupe_seq = resampled[:, None] == spinsamples[:, :n]
-            if dupe_seq.all(axis=0).any():
-                duplicated = True
+            if check_duplicates:
+                if np.any(np.all(resampled[:, None] == spinsamples[:, :n], 0)):
+                    duplicated = True
 
         # if we broke out because we tried 500 rotations and couldn't generate
         # a new one, just warn that we're using duplicate rotations and give up
+        # this should only be triggered if check_duplicates is set to True
         if count == 500 and not warned:
-            warnings.warn('WANRING: Duplicate rotations used. Check '
-                          'resampling array to determine real number of '
-                          'unique permutations.')
+            warnings.warn('Duplicate rotations used. Check resampling array '
+                          'to determine real number of unique permutations.')
             warned = True
 
-        # caclulate cost of rotation in terms of distance b/w node assignments
-        cost[n] = dist_l[lrow, lcol].sum() + dist_r[rrow, rcol].sum()
-
-        # store resampling vector
         spinsamples[:, n] = resampled
+        cost[n] = ccost
 
     return spinsamples, cost

--- a/netneurotools/tests/test_stats.py
+++ b/netneurotools/tests/test_stats.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""
+For testing netneurotools.stats functionality
+"""
+
+import itertools
+import numpy as np
+import pytest
+
+from netneurotools import stats
+
+
+def test_gen_rotation():
+    # make a few rotations (some same / different)
+    rout1, lout1 = stats._gen_rotation(seed=1234)
+    rout2, lout2 = stats._gen_rotation(seed=1234)
+    rout3, lout3 = stats._gen_rotation(seed=5678)
+
+    # confirm consistency with the same seed
+    assert np.allclose(rout1, rout2) and np.allclose(lout1, lout2)
+
+    # confirm inconsistency with different seeds
+    assert not np.allclose(rout1, rout3) and not np.allclose(lout1, lout3)
+
+    # confirm reflection across L/R hemispheres as expected
+    # also confirm min/max never exceeds -1/1
+    reflected = np.array([[1, -1, -1], [-1, 1, 1], [-1, 1, 1]])
+    for r, l in zip([rout1, rout3], [lout1, lout3]):
+        assert np.allclose(r / l, reflected)
+        assert r.max() < 1 and r.min() > -1 and l.max() < 1 and l.min() > -1
+
+
+def _get_sphere_coords(s, t, r=1):
+    """ Gets coordinates at angles `s` and `t` a sphere of radius `r`
+    """
+    # convert to radians
+    rad = np.pi / 180
+    s, t = s * rad, t * rad
+
+    # calculate new points
+    x = r * np.cos(s) * np.sin(t)
+    y = r * np.sin(s) * np.cos(t)
+    z = r * np.cos(t)
+
+    return x, y, z
+
+
+def test_gen_spinsamples():
+    # grab a few points from a spherical surface and duplicate it for the
+    # "other hemisphere"
+    coords = [_get_sphere_coords(s, t, r=1) for s, t in
+              itertools.product(range(0, 360, 45), range(0, 360, 45))]
+    coords = np.row_stack([coords, coords])
+    hemi = np.hstack([np.zeros(len(coords) // 2), np.ones(len(coords) // 2)])
+
+    # generate "normal" test spins
+    spins, cost = stats.gen_spinsamples(coords, hemi, n_rotate=10, seed=1234)
+    assert spins.shape == (len(coords), 10)
+    assert len(cost) == 10
+
+    # confirm that `exact` parameter functions as desired
+    spin_exact, cost_exact = stats.gen_spinsamples(coords, hemi, n_rotate=10,
+                                                   exact=True, seed=1234)
+    assert len(spin_exact) == len(coords)
+    assert len(spin_exact.T) == len(cost_exact) == 10
+    for s in spin_exact.T:
+        assert len(np.unique(s)) == len(s)
+
+    # confirm that check_duplicates will raise warnings
+    # since spins aren't exact permutations we need to use 4C4 with repeats
+    # and then perform one more rotation than that number (i.e., 35 + 1)
+    with pytest.warns(UserWarning):
+        i = [0, 1, -2, -1]  # only grab a few coordinates
+        stats.gen_spinsamples(coords[i], hemi[i], n_rotate=36, seed=1234)
+
+    # non-3D coords
+    with pytest.raises(ValueError):
+        stats.gen_spinsamples(coords[:, :2], hemi)
+
+    # non-1D hemi
+    with pytest.raises(ValueError):
+        stats.gen_spinsamples(coords, np.column_stack([hemi, hemi]))
+
+    # different length coords and hemi
+    with pytest.raises(ValueError):
+        stats.gen_spinsamples(coords, hemi[:-1])
+
+    # only one hemisphere
+    # TODO: should this be allowed?
+    with pytest.raises(ValueError):
+        stats.gen_spinsamples(coords[hemi == 0], hemi[hemi == 0])


### PR DESCRIPTION
Also adds some (super basic) tests for the function :tada:

Removes need to calculate full distance matrix to reassign coordinates during rotations, instead opting to use cKDTree for efficient nearest-neighbor lookup. Also adds a new parameter, `check_duplicates`, that allows users to turn off any warnings that might arise from perfectly duplicate spins / reassignments (which can, with very large inputs, be quite time consuming).

To Do:
- [x] Finish Notes section of doc-string for `gen_spinsamples()`
- [ ] Add some examples to gallery for spin-tests, three ways (or four ways?)