### PR TITLE
[REF, ENH] Refactors `nntools.datasets` module

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -158,6 +158,7 @@ Functions to download real-world datasets
    :template: function.rst
    :toctree: generated/
 
+   fetch_connectome
    fetch_mirchi2018
 
 Functions to generate (pseudo-random) datasets

--- a/netneurotools/data/osf.json
+++ b/netneurotools/data/osf.json
@@ -1,0 +1,267 @@
+{
+    "atl-cammoun2012": {
+        "gcs": {
+            "url": [
+                "mb37e",
+                "5ce6bb4423fec40017e82c5e"
+            ],
+            "md5": "c3435f2720da6a74c3d55db54ebdbfff"
+        },
+        "surface": {
+            "url": [
+                "mb37e",
+                "5ce6c30523fec40017e83439"
+            ],
+            "md5": "478599b362a88198396fdb15ad999f9e"
+        },
+        "volume": {
+            "url": [
+                "mb37e",
+                "5ce6bb438d6e05001860abca"
+            ],
+            "md5": "088fb64b397557dfa01901f04f4cd9d2"
+        }
+    },
+    "atl-pauli2018": [
+        {
+            "url": [
+                "jkzwp",
+                "5b11fa3364f25a001973dce0"
+            ],
+            "md5": "62dd6ff405d3a8b89ee188cafa3a7f6a",
+            "name": "atl-pauli2018/atl-Pauli2018_space-MNI152NLin2009cAsym_hemi-both_probabilistic.nii.gz"
+        },
+        {
+            "url": [
+                "jkzwp",
+                "5b11fa2ff1f288000e625a7f"
+            ],
+            "md5": "5a5b6246921be08456304875447c68ed",
+            "name": "atl-pauli2018/atl-Pauli2018_space-MNI152NLin2009cAsym_hemi-both_deterministic.nii.gz"
+        },
+        {
+            "url": [
+                "mb37e",
+                "5c93b4f034062c001b1ef50d"
+            ],
+            "md5": "390a693abeb1a583151f30aa8798bab5",
+            "name": "atl-pauli2018/atl-Pauli2018_space-MNI152NLin2009cAsym_info.csv"
+        }
+    ],
+    "tpl-conte69": {
+        "url": [
+            "fvuh8",
+            "5b198ec5ec24e20011b48548"
+        ],
+        "md5": "bd944e3f9f343e0e51e562b440960529"
+    },
+    "tpl-fsaverage": {
+        "url": [
+            "mb37e",
+            "5c82830a1d73810018bdacea"
+        ],
+        "md5": "3d2b99fd6c623e17ace6409c4207027a"
+    },
+    "ds-connectomes": {
+        "celegans": {
+            "url": [
+                "mb37e",
+                "5d9b8e4aa7bc73000be65508"
+            ],
+            "md5": "f35cd893bc1aff4e8184a528fcda14b9",
+            "keys": [
+                "conn",
+                "dist",
+                "labels"
+            ]
+        },
+        "drosophila": {
+            "url": [
+                "mb37e",
+                "5d9b8e4aa7bc73000ce65d00"
+            ],
+            "md5": "6a67a4fc1b4f35b72c42cca4d0827249",
+            "keys": [
+                "conn",
+                "coords",
+                "labels",
+                "networks"
+            ]
+        },
+        "human_func_scale033": {
+            "url": [
+                "mb37e",
+                "5d9b8e4afcf91f000f18f57b"
+            ],
+            "md5": "1988ab427d9bc0de075bbe600ce0a27f",
+            "keys": [
+                "conn",
+                "coords",
+                "labels"
+            ]
+        },
+        "human_func_scale060": {
+            "url": [
+                "mb37e",
+                "5d9b8e4aa7bc73000de67117"
+            ],
+            "md5": "4191f5a2b0c5063dcba9935ea0ef0bfe",
+            "keys": [
+                "conn",
+                "coords",
+                "labels"
+            ]
+        },
+        "human_func_scale125": {
+            "url": [
+                "mb37e",
+                "5d9b8e4b26eb50000e78c987"
+            ],
+            "md5": "533e11cf9fea67d536648c9ef939a5f5",
+            "keys": [
+                "conn",
+                "coords",
+                "labels"
+            ]
+        },
+        "human_func_scale250": {
+            "url": [
+                "mb37e",
+                "5d9b8e4efcf91f0012190ba1"
+            ],
+            "md5": "4abc7324c2a9ae04ef6cf5555149b3f4",
+            "keys": [
+                "conn",
+                "coords",
+                "labels"
+            ]
+        },
+        "human_func_scale500": {
+            "url": [
+                "mb37e",
+                "5d9b8e4ff6b03e000d18b5a1"
+            ],
+            "md5": "637c6057476b2508f15f244d528e156d",
+            "keys": [
+                "conn",
+                "coords",
+                "labels"
+            ]
+        },
+        "human_struct_scale033": {
+            "url": [
+                "mb37e",
+                "5d9b8e4f26eb50000e78c993"
+            ],
+            "md5": "27a2101f2f04e0fc8de09a8248793235",
+            "keys": [
+                "conn",
+                "coords",
+                "dist",
+                "labels"
+            ]
+        },
+        "human_struct_scale060": {
+            "url": [
+                "mb37e",
+                "5d9b8e4da7bc73000be6550e"
+            ],
+            "md5": "9289265ab1bd0fa18611eeaf1afce745",
+            "keys": [
+                "conn",
+                "coords",
+                "dist",
+                "labels"
+            ]
+        },
+        "human_struct_scale125": {
+            "url": [
+                "mb37e",
+                "5d9b8e50f6b03e000e18aa37"
+            ],
+            "md5": "07e60b141809babe8c2645d93cd24984",
+            "keys": [
+                "conn",
+                "coords",
+                "dist",
+                "labels"
+            ]
+        },
+        "human_struct_scale250": {
+            "url": [
+                "mb37e",
+                "5d9b8e51fcf91f001118fdc2"
+            ],
+            "md5": "56f9ca8b4ecc63ef9aaf64a606755c09",
+            "keys": [
+                "conn",
+                "coords",
+                "dist",
+                "labels"
+            ]
+        },
+        "human_struct_scale500": {
+            "url": [
+                "mb37e",
+                "5d9b8e51a7bc73000ee65769"
+            ],
+            "md5": "94724e0446f8cb06207a4521ba1df20f",
+            "keys": [
+                "conn",
+                "coords",
+                "dist",
+                "labels"
+            ]
+        },
+        "macaque_markov": {
+            "url": [
+                "mb37e",
+                "5d9b8e56a7bc73000ce65d11"
+            ],
+            "md5": "5ce43182afc9c4f779db2c0306afb202",
+            "keys": [
+                "conn",
+                "dist",
+                "labels"
+            ]
+        },
+        "macaque_modha": {
+            "url": [
+                "mb37e",
+                "5d9b8e5626eb50000d78abd0"
+            ],
+            "md5": "f467c62b2670feaf75c93d90d5ed5de6",
+            "keys": [
+                "conn",
+                "coords",
+                "dist",
+                "labels"
+            ]
+        },
+        "mouse": {
+            "url": [
+                "mb37e",
+                "5d9b8e5626eb50000e78c9a0"
+            ],
+            "md5": "dba5cbbb9e72c1cacda945086d77a125",
+            "keys": [
+                "conn",
+                "coords",
+                "dist",
+                "labels",
+                "acronyms"
+            ]
+        },
+        "rat": {
+            "url": [
+                "mb37e",
+                "5d9b8e56f6b03e000f18d06f"
+            ],
+            "md5": "9e1f12ce4fa42082a76d62f89670f5d0",
+            "keys": [
+                "conn",
+                "labels"
+            ]
+        }
+    }
+}

--- a/netneurotools/datasets/__init__.py
+++ b/netneurotools/datasets/__init__.py
@@ -4,9 +4,12 @@ Functions for fetching and generating datasets
 
 __all__ = [
     'fetch_cammoun2012', 'fetch_conte69', 'fetch_fsaverage', 'fetch_pauli2018',
-    'make_correlated_xy', 'fetch_mirchi2018'
+    'make_correlated_xy', 'fetch_mirchi2018', 'fetch_connectome',
+    'available_connectomes'
 ]
 
-from .datasets import (fetch_cammoun2012, fetch_conte69, fetch_fsaverage,
-                       fetch_pauli2018, make_correlated_xy)
+from .fetchers import (fetch_cammoun2012, fetch_conte69, fetch_fsaverage,
+                       fetch_pauli2018, fetch_connectome,
+                       available_connectomes)
+from .generators import (make_correlated_xy)
 from .mirchi import (fetch_mirchi2018)

--- a/netneurotools/datasets/fetchers.py
+++ b/netneurotools/datasets/fetchers.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 """
-Dataset fetcher / creation / whathaveyou
+Functions for fetching datasets from the internet
 """
 
 import itertools
 import json
 import os
+import os.path as op
 
 from nilearn.datasets.utils import _fetch_files
 import numpy as np
 from sklearn.utils import Bunch
-from sklearn.utils.validation import check_random_state
 
 from .utils import _get_data_dir, _get_dataset_info
 
@@ -38,11 +38,12 @@ def fetch_cammoun2012(version='volume', data_dir=None, url=None, resume=True,
         Whether to attempt to resume partial download, if possible. Default:
         True
     verbose : int, optional
-        Does nothing. Default: 1
+        Modifies verbosity of download, where higher numbers mean more updates.
+        Default: 1
 
     Returns
     -------
-    filenames : :class:`sklearn.utils.Busnch`
+    filenames : :class:`sklearn.utils.Bunch`
         Dictionary-like object with keys ['scale033', 'scale060', 'scale125',
         'scale250', 'scale500'], where corresponding values are lists of
         filepaths to downloaded parcellation files.
@@ -126,11 +127,12 @@ def fetch_conte69(data_dir=None, url=None, resume=True, verbose=1):
         Whether to attempt to resume partial download, if possible. Default:
         True
     verbose : int, optional
-        Does nothing. Default: 1
+        Modifies verbosity of download, where higher numbers mean more updates.
+        Default: 1
 
     Returns
     -------
-    filenames : :class:`sklearn.utils.Busnch`
+    filenames : :class:`sklearn.utils.Bunch`
         Dictionary-like object with keys ['midthickness', 'inflated',
         'vinflated'], where corresponding values are lists of filepaths to
         downloaded template files.
@@ -196,7 +198,8 @@ def fetch_pauli2018(data_dir=None, url=None, resume=True, verbose=1):
         Whether to attempt to resume partial download, if possible. Default:
         True
     verbose : int, optional
-        Does nothing. Default: 1
+        Modifies verbosity of download, where higher numbers mean more updates.
+        Default: 1
 
     Returns
     -------
@@ -248,7 +251,8 @@ def fetch_fsaverage(data_dir=None, url=None, resume=True, verbose=1):
         Whether to attempt to resume partial download, if possible. Default:
         True
     verbose : int, optional
-        Does nothing. Default: 1
+        Modifies verbosity of download, where higher numbers mean more updates.
+        Default: 1
 
     Returns
     -------
@@ -288,89 +292,87 @@ def fetch_fsaverage(data_dir=None, url=None, resume=True, verbose=1):
     return Bunch(**dict(zip(keys, data)))
 
 
-def make_correlated_xy(corr=0.85, size=10000, seed=None, tol=0.001):
+def available_connectomes():
     """
-    Generates random vectors that are correlated to approximately `corr`
-
-    Parameters
-    ----------
-    corr : [-1, 1] float or (N, N) numpy.ndarray, optional
-        The approximate correlation desired. If a float is provided, two
-        vectors with the specified level of correlation will be generated. If
-        an array is provided, it is assumed to be a symmetrical correlation
-        matrix and ``len(corr)`` vectors with the specified levels of
-        correlation will be generated. Default: 0.85
-    size : int or tuple, optional
-        Desired size of the generated vectors. Default: 1000
-    seed : {int, np.random.RandomState instance, None}, optional
-        Seed for random number generation. Default: None
-    tol : [0, 1] float, optional
-        Tolerance of correlation between generated `vectors` and specified
-        `corr`. Default: 0.05
+    Lists datasets available via :func:`~.fetch_connectome`
 
     Returns
     -------
-    vectors : numpy.ndarray
-        Random vectors of size `size` with correlation specified by `corr`
-
-    Examples
-    --------
-    >>> from netneurotools import datasets
-
-    By default two vectors are generated with specified correlation
-
-    >>> x, y = datasets.make_correlated_xy()
-    >>> np.corrcoef(x, y)  # doctest: +SKIP
-    array([[1.        , 0.85083661],
-           [0.85083661, 1.        ]])
-    >>> x, y = datasets.make_correlated_xy(corr=0.2)
-    >>> np.corrcoef(x, y)  # doctest: +SKIP
-    array([[1.        , 0.20069953],
-           [0.20069953, 1.        ]])
-
-    You can also provide correlation matrices to generate more than two vectors
-    if desired. Note that this makes it more difficult to ensure the actual
-    correlations are close to the desired values:
-
-    >>> corr = [[1, 0.5, 0.3], [0.5, 1, 0], [0.3, 0, 1]]
-    >>> out = datasets.make_correlated_xy(corr=corr)
-    >>> out.shape
-    (3, 10000)
-    >>> np.corrcoef(out)  # doctest: +SKIP
-    array([[1.        , 0.50965273, 0.30235686],
-           [0.50965273, 1.        , 0.01089107],
-           [0.30235686, 0.01089107, 1.        ]])
+    datasets : list of str
+        List of available datasets
     """
 
-    rs = check_random_state(seed)
+    return sorted(_get_dataset_info('ds-connectomes').keys())
 
-    # no correlations outside [-1, 1] bounds
-    if np.any(np.abs(corr) > 1):
-        raise ValueError('Provided `corr` must (all) be in range [-1, 1].')
 
-    # if we're given a single number, assume two vectors are desired
-    if isinstance(corr, (int, float)):
-        covs = np.ones((2, 2)) * 0.111
-        covs[(0, 1), (1, 0)] *= corr
-    # if we're given a correlation matrix, assume `N` vectors are desired
-    elif isinstance(corr, (list, np.ndarray)):
-        corr = np.asarray(corr)
-        if corr.ndim != 2 or len(corr) != len(corr.T):
-            raise ValueError('If `corr` is a list or array, must be a 2D '
-                             'square array, not {}'.format(corr.shape))
-        if np.any(np.diag(corr) != 1):
-            raise ValueError('Diagonal of `corr` must be 1.')
-        covs = corr * 0.111
-    means = [0] * len(covs)
+def fetch_connectome(dataset, data_dir=None, url=None, resume=True,
+                     verbose=1):
+    """
+    Downloads files for Cammoun et al., 2012 multiscale parcellation
 
-    # generate the variables
-    count = 0
-    while count < 500:
-        vectors = rs.multivariate_normal(mean=means, cov=covs, size=size).T
-        flat = vectors.reshape(len(vectors), -1)
-        # if diff between actual and desired correlations less than tol, break
-        if np.all(np.abs(np.corrcoef(flat) - (covs / 0.111)) < tol):
-            break
-        count += 1
+    Parameters
+    ----------
+    dataset : str
+        Specifies which dataset to download; must be one of the datasets listed
+        in :func:`netneurotools.datasets.available_connectomes()`.
+    data_dir : str, optional
+        Path to use as data directory. If not specified, will check for
+        environmental variable 'NNT_DATA'; if that is not set, will use
+        `~/nnt-data` instead. Default: None
+    url : str, optional
+        URL from which to download data. Default: None
+    resume : bool, optional
+        Whether to attempt to resume partial download, if possible. Default:
+        True
+    verbose : int, optional
+        Modifies verbosity of download, where higher numbers mean more updates.
+        Default: 1
 
-    return vectors
+    Returns
+    -------
+    data : :class:`sklearn.utils.Bunch`
+        Dictionary-like object with, at a minimum, keys ['conn', 'labels',
+        'ref'] providing connectivity / correlation matrix, region labels, and
+        relevant reference. Other possible keys include 'dist' (an array of
+        Euclidean distances between regions of 'conn'), 'coords' (an array of
+        xyz coordinates for regions of 'conn'), 'acronyms' (an array of
+        acronyms for regions of 'conn'), and 'networks' (an array of network
+        affiliations for regions of 'conn')
+
+    References
+    ----------
+    See `ref` key of returned dictionary object for relevant dataset reference
+    """
+
+    if dataset not in available_connectomes():
+        raise ValueError('Provided dataset {} not available; must be one of {}'
+                         .format(dataset, available_connectomes()))
+
+    dataset_name = 'ds-connectomes'
+
+    data_dir = op.join(_get_data_dir(data_dir=data_dir), dataset_name)
+    info = _get_dataset_info(dataset_name)[dataset]
+    if url is None:
+        url = info['url']
+    opts = {
+        'uncompress': True,
+        'md5sum': info['md5'],
+        'move': '{}.tar.gz'.format(dataset)
+    }
+
+    filenames = [
+        os.path.join(dataset, '{}.csv'.format(fn)) for fn in info['keys']
+    ] + [op.join(dataset, 'ref.txt')]
+    data = _fetch_files(data_dir, files=[(f, url, opts) for f in filenames],
+                        resume=resume, verbose=verbose)
+
+    # load data
+    for n, arr in enumerate(data[:-1]):
+        try:
+            data[n] = np.loadtxt(arr, delimiter=',')
+        except ValueError:
+            data[n] = np.loadtxt(arr, delimiter=',', dtype=str)
+    with open(data[-1]) as src:
+        data[-1] = src.read().strip()
+
+    return Bunch(**dict(zip(info['keys'] + ['ref'], data)))

--- a/netneurotools/datasets/generators.py
+++ b/netneurotools/datasets/generators.py
@@ -1,0 +1,96 @@
+
+# -*- coding: utf-8 -*-
+"""
+Functions for making "random" datasets
+"""
+
+import numpy as np
+from sklearn.utils.validation import check_random_state
+
+
+def make_correlated_xy(corr=0.85, size=10000, seed=None, tol=0.001):
+    """
+    Generates random vectors that are correlated to approximately `corr`
+
+    Parameters
+    ----------
+    corr : [-1, 1] float or (N, N) numpy.ndarray, optional
+        The approximate correlation desired. If a float is provided, two
+        vectors with the specified level of correlation will be generated. If
+        an array is provided, it is assumed to be a symmetrical correlation
+        matrix and ``len(corr)`` vectors with the specified levels of
+        correlation will be generated. Default: 0.85
+    size : int or tuple, optional
+        Desired size of the generated vectors. Default: 1000
+    seed : {int, np.random.RandomState instance, None}, optional
+        Seed for random number generation. Default: None
+    tol : [0, 1] float, optional
+        Tolerance of correlation between generated `vectors` and specified
+        `corr`. Default: 0.001
+
+    Returns
+    -------
+    vectors : numpy.ndarray
+        Random vectors of size `size` with correlation specified by `corr`
+
+    Examples
+    --------
+    >>> from netneurotools import datasets
+
+    By default two vectors are generated with specified correlation
+
+    >>> x, y = datasets.make_correlated_xy()
+    >>> np.corrcoef(x, y)  # doctest: +SKIP
+    array([[1.        , 0.85083661],
+           [0.85083661, 1.        ]])
+    >>> x, y = datasets.make_correlated_xy(corr=0.2)
+    >>> np.corrcoef(x, y)  # doctest: +SKIP
+    array([[1.        , 0.20069953],
+           [0.20069953, 1.        ]])
+
+    You can also provide correlation matrices to generate more than two vectors
+    if desired. Note that this makes it more difficult to ensure the actual
+    correlations are close to the desired values:
+
+    >>> corr = [[1, 0.5, 0.3], [0.5, 1, 0], [0.3, 0, 1]]
+    >>> out = datasets.make_correlated_xy(corr=corr)
+    >>> out.shape
+    (3, 10000)
+    >>> np.corrcoef(out)  # doctest: +SKIP
+    array([[1.        , 0.50965273, 0.30235686],
+           [0.50965273, 1.        , 0.01089107],
+           [0.30235686, 0.01089107, 1.        ]])
+    """
+
+    rs = check_random_state(seed)
+
+    # no correlations outside [-1, 1] bounds
+    if np.any(np.abs(corr) > 1):
+        raise ValueError('Provided `corr` must (all) be in range [-1, 1].')
+
+    # if we're given a single number, assume two vectors are desired
+    if isinstance(corr, (int, float)):
+        covs = np.ones((2, 2)) * 0.111
+        covs[(0, 1), (1, 0)] *= corr
+    # if we're given a correlation matrix, assume `N` vectors are desired
+    elif isinstance(corr, (list, np.ndarray)):
+        corr = np.asarray(corr)
+        if corr.ndim != 2 or len(corr) != len(corr.T):
+            raise ValueError('If `corr` is a list or array, must be a 2D '
+                             'square array, not {}'.format(corr.shape))
+        if np.any(np.diag(corr) != 1):
+            raise ValueError('Diagonal of `corr` must be 1.')
+        covs = corr * 0.111
+    means = [0] * len(covs)
+
+    # generate the variables
+    count = 0
+    while count < 500:
+        vectors = rs.multivariate_normal(mean=means, cov=covs, size=size).T
+        flat = vectors.reshape(len(vectors), -1)
+        # if diff between actual and desired correlations less than tol, break
+        if np.all(np.abs(np.corrcoef(flat) - (covs / 0.111)) < tol):
+            break
+        count += 1
+
+    return vectors

--- a/netneurotools/datasets/utils.py
+++ b/netneurotools/datasets/utils.py
@@ -9,14 +9,33 @@ from pkg_resources import resource_filename
 
 
 def _osfify_urls(data):
+    """
+    Formats `data` object with OSF API URL
+
+    Parameters
+    ----------
+    data : object
+        If dict with a `url` key, will format OSF_API with relevant values
+
+    Returns
+    -------
+    data : object
+        Input data with all `url` dict keys formatted
+    """
+
     OSF_API = "https://files.osf.io/v1/resources/{}/providers/osfstorage/{}"
 
-    for key, value in data.items():
-        if isinstance(value, dict):
-            try:
-                data[key]['url'] = OSF_API.format(*value['url'])
-            except KeyError:
-                data[key] = _osfify_urls(value)
+    if isinstance(data, str):
+        return data
+    elif 'url' in data:
+        data['url'] = OSF_API.format(*data['url'])
+
+    try:
+        for key, value in data.items():
+            data[key] = _osfify_urls(value)
+    except AttributeError:
+        for n, value in enumerate(data):
+            data[n] = _osfify_urls(value)
 
     return data
 

--- a/netneurotools/datasets/utils.py
+++ b/netneurotools/datasets/utils.py
@@ -3,51 +3,26 @@
 Utilites for loading / creating datasets
 """
 
+import json
 import os
+from pkg_resources import resource_filename
 
-OSF_API = "https://files.osf.io/v1/resources/{}/providers/osfstorage/{}"
-OSF_RESOURCES = {
-    'atl-cammoun2012': {
-        'gcs': {
-            'url': OSF_API.format('mb37e', '5ce6bb4423fec40017e82c5e'),
-            'md5': 'c3435f2720da6a74c3d55db54ebdbfff'
-        },
-        'surface': {
-            'url': OSF_API.format('mb37e', '5ce6c30523fec40017e83439'),
-            'md5': '478599b362a88198396fdb15ad999f9e'
-        },
-        'volume': {
-            'url': OSF_API.format('mb37e', '5ce6bb438d6e05001860abca'),
-            'md5': '088fb64b397557dfa01901f04f4cd9d2'
-        }
-    },
-    'atl-pauli2018': [
-        {
-            'url': OSF_API.format('jkzwp', '5b11fa3364f25a001973dce0'),
-            'md5': '62dd6ff405d3a8b89ee188cafa3a7f6a',
-            'name': 'atl-pauli2018/atl-Pauli2018_space-MNI152NLin2009cAsym_hemi-both_probabilistic.nii.gz'  # noqa
-        },
-        {
-            'url': OSF_API.format('jkzwp', '5b11fa2ff1f288000e625a7f'),
-            'md5': '5a5b6246921be08456304875447c68ed',
-            'name': 'atl-pauli2018/atl-Pauli2018_space-MNI152NLin2009cAsym_hemi-both_deterministic.nii.gz'  # noqa
-        },
-        {
-            'url': OSF_API.format('mb37e', '5c93b4f034062c001b1ef50d'),
-            'md5': '390a693abeb1a583151f30aa8798bab5',
-            'name': 'atl-pauli2018/atl-Pauli2018_space-MNI152NLin2009cAsym_info.csv'  # noqa
-        }
-    ],
-    # thanks to poldracklab team for uploading these useful datasets!
-    'tpl-conte69': {
-        'url': OSF_API.format('fvuh8', '5b198ec5ec24e20011b48548'),
-        'md5': 'bd944e3f9f343e0e51e562b440960529'
-    },
-    'tpl-fsaverage': {
-        'url': OSF_API.format('mb37e', '5c82830a1d73810018bdacea'),
-        'md5': '3d2b99fd6c623e17ace6409c4207027a',
-    }
-}
+
+def _osfify_urls(data):
+    OSF_API = "https://files.osf.io/v1/resources/{}/providers/osfstorage/{}"
+
+    for key, value in data.items():
+        if isinstance(value, dict):
+            try:
+                data[key]['url'] = OSF_API.format(*value['url'])
+            except KeyError:
+                data[key] = _osfify_urls(value)
+
+    return data
+
+
+with open(resource_filename('netneurotools', 'data/osf.json')) as src:
+    OSF_RESOURCES = _osfify_urls(json.load(src))
 
 
 def _get_dataset_info(name):
@@ -70,8 +45,8 @@ def _get_dataset_info(name):
     try:
         return OSF_RESOURCES[name]
     except KeyError:
-        raise KeyError('Provided dataset "{}" is not valid. Must be one of: {}'
-                       .format(name, list(OSF_RESOURCES.keys())))
+        raise KeyError("Provided dataset '{}' is not valid. Must be one of: {}"
+                       .format(name, sorted(OSF_RESOURCES.keys())))
 
 
 def _get_data_dir(data_dir=None):

--- a/netneurotools/tests/test_datasets.py
+++ b/netneurotools/tests/test_datasets.py
@@ -87,6 +87,32 @@ def test_fetch_cammoun2012(tmpdir, version, expected):
             assert isinstance(out, str) and out.endswith('.nii.gz')
 
 
+@pytest.mark.parametrize('dataset, expected', [
+    ('celegans', ['conn', 'dist', 'labels', 'ref']),
+    ('drosophila', ['conn', 'coords', 'labels', 'networks', 'ref']),
+    ('human_func_scale033', ['conn', 'coords', 'labels', 'ref']),
+    ('human_func_scale060', ['conn', 'coords', 'labels', 'ref']),
+    ('human_func_scale125', ['conn', 'coords', 'labels', 'ref']),
+    ('human_func_scale250', ['conn', 'coords', 'labels', 'ref']),
+    ('human_func_scale500', ['conn', 'coords', 'labels', 'ref']),
+    ('human_struct_scale033', ['conn', 'coords', 'dist', 'labels', 'ref']),
+    ('human_struct_scale060', ['conn', 'coords', 'dist', 'labels', 'ref']),
+    ('human_struct_scale125', ['conn', 'coords', 'dist', 'labels', 'ref']),
+    ('human_struct_scale250', ['conn', 'coords', 'dist', 'labels', 'ref']),
+    ('human_struct_scale500', ['conn', 'coords', 'dist', 'labels', 'ref']),
+    ('macaque_markov', ['conn', 'dist', 'labels', 'ref']),
+    ('macaque_modha', ['conn', 'coords', 'dist', 'labels', 'ref']),
+    ('mouse', ['acronyms', 'conn', 'coords', 'dist', 'labels', 'ref']),
+    ('rat', ['conn', 'labels', 'ref']),
+])
+def test_fetch_connectome(tmpdir, dataset, expected):
+    connectome = datasets.fetch_connectome(dataset, data_dir=tmpdir, verbose=0)
+
+    for key in expected:
+        assert (key in connectome)
+        assert isinstance(connectome[key], str if key == 'ref' else np.ndarray)
+
+
 @pytest.mark.parametrize('dset, expected', [
     ('atl-cammoun2012', ['volume', 'surface', 'gcs']),
     ('tpl-conte69', ['url', 'md5']),


### PR DESCRIPTION
**ENH**: Adds a `fetch_connectome()` function for getting species-specific structural/functional connectivity matrices.

**REF**: Separates dataset fetchers from dataset generators and moves former `OSF_RESOURCES` dictionary into `data/osf.json` for easier maintenance.

To Do:
- [x] Add tests for new dataset fetchers