### PR TITLE
[FIX] Fixes parcel dropping in nntools.freesurfer

### DIFF
--- a/netneurotools/tests/test_freesurfer.py
+++ b/netneurotools/tests/test_freesurfer.py
@@ -12,7 +12,7 @@ from netneurotools import datasets, freesurfer
 @pytest.fixture(scope='module')
 def cammoun_surf(tmp_path_factory):
     tmpdir = str(tmp_path_factory.getbasetemp())
-    return datasets.fetch_cammoun2012('surface', data_dir=tmpdir, verbose=0)
+    return datasets.fetch_cammoun2012('fsaverage', data_dir=tmpdir, verbose=0)
 
 
 @pytest.mark.parametrize('scale, parcels', [


### PR DESCRIPTION
When names in `drop` parameter weren't present in provided annotation files the function(s) would errored; this is now resolved.

Also adds a new parcel to drop by default commonly found in CBIG parcellations (`'Background+FreeSurfer_Defined_Medial_Wall'`).