### PR TITLE
[FIX] Fixes pysurfer opacity bug

### DIFF
--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -465,8 +465,14 @@ def plot_fsaverage(data, *, lhannot, rhannot, order='LR', surf='pial',
 
         # finally, add data to this hemisphere!
         brain.add_data(vtx_data, vmin, vmax, hemi=hemi, mid=center,
-                       thresh=thresh + 0.5, alpha=alpha, remove_existing=False,
+                       thresh=thresh + 0.5, alpha=1.0, remove_existing=False,
                        colormap=colormap, colorbar=colorbar, verbose=False)
+
+        if alpha != 1.0:
+            surf = brain.data_dict[hemi]['surfaces']
+            for n, s in enumerate(surf):
+                s.actor.property.opacity = alpha
+                s.render()
 
         # if we have a colorbar, update parameters accordingly
         if colorbar:


### PR DESCRIPTION
Requires nipy/pysurfer@dd9f3b5 (or newer).

Also, modify `site-packages/vtkmodules/qt/__init__.py` file and make this change:

```diff
# QVTKRWIBase, base class for QVTKRenderWindowInteractor,
# can be altered by the user to "QGLWidget" in case
# of rendering errors (e.g. depth check problems, readGLBuffer
# warnings...)
-QVTKRWIBase = "QWidget"
+QVTKRWIBase = "QGLWidget"
```

and modify `site-packages/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py` and make this change:

```diff
if PyQtImpl == "PyQt5":
    if QVTKRWIBase == "QGLWidget":
-        try:
-            from PyQt5.QtWidgets import QOpenGLWidget as QGLWidget
-        except:
-            from PyQt5.QtOpenGL import QGLWidget
+       from PyQt5.QtOpenGL import QGLWidget
```

Make sure you have `vtk>=8.2` and `pyqt>=5.9.2` installed. Now you shouldn't get weird speckling when plotting with `nnplot.plot_fsaverage()`!