### PR TITLE
[FIX] np.nanmean in func consensus when no boot

### DIFF
--- a/netneurotools/networks.py
+++ b/netneurotools/networks.py
@@ -64,7 +64,7 @@ def func_consensus(data, n_boot=1000, ci=95, seed=None):
         else:
             corrs = [np.corrcoef(data[..., sub]) for sub in
                      range(data.shape[-1])]
-        return np.mean(corrs, axis=0)
+        return np.nanmean(corrs, axis=0)
 
     if isinstance(data, list):
         collapsed_data = np.hstack(data)


### PR DESCRIPTION
Changed np.mean() to np.nanmean() in func_consensus() function, when the consensus matrix is computed without any bootstrap.

This change is useful for a few cases where an individual subject has no BOLD signal data for an individual node (0s at every time point). When this happen, you don't want to completely ignore the subject, but you want to ignore the NaN correlations that np.corrcoef will return for pairwise correlations with this node. 

Example: Subject 39, node 113 in func_scale500.npy file 