### PR TITLE
[ENH] Allows spins with only one hemisphere 

### DIFF
--- a/netneurotools/stats.py
+++ b/netneurotools/stats.py
@@ -691,7 +691,7 @@ def gen_spinsamples(coords, hemiid, n_rotate=1000, check_duplicates=True,
         raise ValueError('Provided `coords` and `hemiid` must have the same '
                          'length. Provided lengths: coords = {}, hemiid = {}'
                          .format(len(coords), len(hemiid)))
-    if np.max(hemiid) != 1 or np.min(hemiid) != 0:
+    if np.max(hemiid) > 1 or np.min(hemiid) < 0:
         raise ValueError('Hemiid must have values in {0, 1} denoting left and '
                          'right hemisphere coordinates, respectively. '
                          + 'Provided array contains values: {}'
@@ -719,6 +719,8 @@ def gen_spinsamples(coords, hemiid, n_rotate=1000, check_duplicates=True,
             for h, rot in enumerate(_gen_rotation(seed=seed)):
                 hinds = (hemiid == h)
                 coor = coords[hinds]
+                if len(coor) == 0:
+                    continue
 
                 # if we need an "exact" mapping (i.e., each node needs to be
                 # assigned EXACTLY once) then we have to calculate the full

--- a/netneurotools/tests/test_stats.py
+++ b/netneurotools/tests/test_stats.py
@@ -137,19 +137,23 @@ def test_gen_spinsamples():
     # generate "normal" test spins
     spins, cost = stats.gen_spinsamples(coords, hemi, n_rotate=10, seed=1234,
                                         return_cost=True)
-    assert spins.shape == (len(coords), 10)
-    assert cost.shape == (len(coords), 10)
+    assert spins.shape == spins.shape == (len(coords), 10)
 
-    # confirm that `exact` parameter functions as desired
+    # confirm that `method` parameter functions as desired
     for method in ['vasa', 'hungarian']:
         spin_exact, cost_exact = stats.gen_spinsamples(coords, hemi,
                                                        n_rotate=10, seed=1234,
                                                        method=method,
                                                        return_cost=True)
-        assert spin_exact.shape == (len(coords), 10)
-        assert cost.shape == (len(coords), 10)
+        assert spin_exact.shape == cost.shape == (len(coords), 10)
         for s in spin_exact.T:
             assert len(np.unique(s)) == len(s)
+
+    # check that one hemisphere works
+    mask = hemi == 0
+    spins, cost = stats.gen_spinsamples(coords[mask], hemi[mask], n_rotate=10,
+                                        seed=1234, return_cost=True)
+    assert spins.shape == cost.shape == (len(coords[mask]), 10)
 
     # confirm that check_duplicates will raise warnings
     # since spins aren't exact permutations we need to use 4C4 with repeats
@@ -169,8 +173,3 @@ def test_gen_spinsamples():
     # different length coords and hemi
     with pytest.raises(ValueError):
         stats.gen_spinsamples(coords, hemi[:-1])
-
-    # only one hemisphere
-    # TODO: should this be allowed?
-    with pytest.raises(ValueError):
-        stats.gen_spinsamples(coords[hemi == 0], hemi[hemi == 0])


### PR DESCRIPTION
Closes #86.

Title is relatively self-explanatory, but now you can provide coordinates for a single hemisphere and `netneurotools.stats.gen_spinsamples()` doesn't fail. Tests are updated to match.