### PR TITLE
[REF] Allow integer inputs in `freesurfer.parcels_to_vertices()`

### DIFF
--- a/netneurotools/freesurfer.py
+++ b/netneurotools/freesurfer.py
@@ -271,7 +271,7 @@ def parcels_to_vertices(data, *, lhannot, rhannot, drop=None):
         drop = FSIGNORE
     drop = _decode_list(drop)
 
-    data = np.vstack(data)
+    data = np.vstack(data).astype(float)
 
     # check this so we're not unduly surprised by anything...
     n_vert = expected = 0

--- a/netneurotools/tests/test_freesurfer.py
+++ b/netneurotools/tests/test_freesurfer.py
@@ -67,6 +67,12 @@ def test_project_reduce_vertices(cammoun_surf, scale, parcels):
     reduced = freesurfer.vertices_to_parcels(projected, rhannot=rh, lhannot=lh)
     assert np.allclose(data, reduced)
 
+    # what about int arrays as input?
+    data = np.random.choice(10, size=parcels)
+    projected = freesurfer.parcels_to_vertices(data, rhannot=rh, lhannot=lh)
+    reduced = freesurfer.vertices_to_parcels(projected, rhannot=rh, lhannot=lh)
+    assert np.allclose(reduced, data)
+
     # number of parcels != annotation spec
     with pytest.raises(ValueError):
         freesurfer.parcels_to_vertices(np.random.rand(parcels + 1),


### PR DESCRIPTION
Closes #84.

Allows integer inputs to `netneurotools.freesurfer.parcels_to_vertices()`. Previously this would error due to the insertion of `np.nan` for "ignored" parcels (e.g., corpus callosum, medial wall).