### PR TITLE
[ENH] Adds function to map CIVET to FreeSurfer

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -197,6 +197,24 @@ Functions to generate (pseudo-random) datasets
    spin_data
    spin_parcels
 
+.. _ref_civet:
+
+:mod:`netneurotools.civet` - CIVET compatibility functions
+----------------------------------------------------------
+
+.. automodule:: netneurotools.civet
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: netneurotools.civet
+
+.. autosummary::
+   :template: function.rst
+   :toctree: generated/
+
+   read_civet
+   civet_to_freesurfer
+
 .. _ref_utils:
 
 :mod:`netneurotools.utils` - Miscellaneous, grab bag utilities

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -149,6 +149,7 @@ Functions to download atlases and templates
    :toctree: generated/
 
     fetch_cammoun2012
+    fetch_civet
     fetch_conte69
     fetch_fsaverage
     fetch_pauli2018

--- a/netneurotools/civet.py
+++ b/netneurotools/civet.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""
+Functions for working with CIVET data (ugh)
+"""
+
+import nibabel as nib
+import numpy as np
+from scipy.spatial import cKDTree
+
+from .datasets import fetch_civet, fetch_fsaverage
+
+_MNI305to152 = np.array([[0.9975, -0.0073, 0.0176, -0.0429],
+                         [0.0146, 1.0009, -0.0024, 1.5496],
+                         [-0.0130, -0.0093, 0.9971, 1.1840]])
+
+
+def read_civet(fname):
+    """
+    Reads a CIVET-style .obj geometry file
+
+    Parameters
+    ----------
+    fname : str or os.PathLike
+        Filepath to .obj file
+
+    Returns
+    -------
+    vertices : (N, 3)
+    triangles : (T, 3)
+    """
+
+    k, polygons = 0, []
+    with open(fname, 'r') as src:
+        n_vert = int(src.readline().split()[6])
+        vertices = np.zeros((n_vert, 3))
+        for i, line in enumerate(src):
+            if i < n_vert:
+                vertices[i] = [float(i) for i in line.split()]
+            elif i >= (2 * n_vert) + 5:
+                if not line.strip():
+                    k = 1
+                elif k == 1:
+                    polygons.extend([int(i) for i in line.split()])
+
+    triangles = np.reshape(np.asarray(polygons), (-1, 3))
+
+    return vertices, triangles
+
+
+def _get_civet_to_fs_mapping(obj, fs):
+    """
+    Returns a mapping between `obj` and `fs` geometry files
+
+    Parameters
+    ----------
+    obj : str or os.PathLike
+        Path to CIVET geometry file
+    fs : str or os.PathLike
+        Path to FreeSurfer geometry file
+
+    Returns
+    -------
+    idx : (N,) np.ndarray
+        Mapping from CIVET to FreeSurfer space
+    """
+
+    vert_cv, _ = read_civet(obj)
+    vert_fs, _ = nib.freesurfer.read_geometry(fs)
+
+    vert_fs = np.c_[vert_fs, np.ones(len(vert_fs))] @ _MNI305to152.T
+    _, idx = cKDTree(vert_cv).query(vert_fs, k=1, distance_upper_bound=10)
+
+    return idx
+
+
+def civet_to_freesurfer(brainmap, surface='mid', version='v1',
+                        freesurfer='fsaverage6', mapping=None, data_dir=None):
+    """
+    Projects `brainmap` in CIVET space to `freesurfer` fsaverage space
+
+    Uses a nearest-neighbor projection based on the geometry of the vertices
+
+    Parameters
+    ----------
+    brainmap : array_like
+        CIVET brainmap to be converted to freesurfer space
+    surface : {'white', 'mid'}, optional
+        Which CIVET surface to use for geometry of `brainmap`. Default: 'mid'
+    version : {'v1', 'v2'}, optional
+        Which CIVET version to use for geometry of `brainmap`. Default: 'v1'
+    freesurfer : str, optional
+        Which version of FreeSurfer space to project data to. Must be one of
+        {'fsaverage', 'fsaverage3', 'fsaverage4', 'fsaverage5', 'fsaverage6'}.
+        Default: 'fsaverage6'
+    mapping : array_like, optional
+        If mapping has been pre-computed for `surface` --> `version` and is
+        provided, this will be used instead of recomputing. Default: None
+    data_dir : str, optional
+        Path to use as data directory. If not specified, will check for
+        environmental variable 'NNT_DATA'; if that is not set, will use
+        `~/nnt-data` instead. Default: None
+
+    Returns
+    -------
+    data : np.ndarray
+        Provided `brainmap` mapped to FreeSurfer
+    """
+
+    densities = (81924, 327684)
+    n_vert = len(brainmap)
+    if n_vert not in densities:
+        raise ValueError('Unable to interpret `brainmap` space; provided '
+                         'array must have length in {}. Received: {}'
+                         .format(densities, n_vert))
+
+    n_vert = n_vert // 2
+    icbm = fetch_civet(density='41k' if n_vert == 40962 else '164k',
+                       version=version, data_dir=data_dir, verbose=0)[surface]
+    fsavg = fetch_fsaverage(version=freesurfer, data_dir=data_dir, verbose=0)
+    fsavg = fsavg['pial' if surface == 'mid' else 'white']
+
+    data = []
+    for n, hemi in enumerate(('lh', 'rh')):
+        sl = slice(n_vert * n, n_vert * (n + 1))
+        if mapping is None:
+            idx = _get_civet_to_fs_mapping(getattr(icbm, hemi),
+                                           getattr(fsavg, hemi))
+        else:
+            idx = mapping[sl]
+
+        data.append(brainmap[sl][idx])
+
+    return np.hstack(data)

--- a/netneurotools/civet.py
+++ b/netneurotools/civet.py
@@ -117,7 +117,7 @@ def civet_to_freesurfer(brainmap, surface='mid', version='v1',
     icbm = fetch_civet(density='41k' if n_vert == 40962 else '164k',
                        version=version, data_dir=data_dir, verbose=0)[surface]
     fsavg = fetch_fsaverage(version=freesurfer, data_dir=data_dir, verbose=0)
-    fsavg = fsavg['pial' if surface == 'mid' else 'white']
+    fsavg = fsavg['pial' if surface == 'mid' else surface]
 
     data = []
     for n, hemi in enumerate(('lh', 'rh')):
@@ -128,6 +128,9 @@ def civet_to_freesurfer(brainmap, surface='mid', version='v1',
         else:
             idx = mapping[sl]
 
-        data.append(brainmap[sl][idx])
+        hdata = np.full(len(idx), np.nan)
+        mask = idx != n_vert
+        hdata[mask] = brainmap[sl][idx[mask]]
+        data.append(hdata)
 
     return np.hstack(data)

--- a/netneurotools/data/osf.json
+++ b/netneurotools/data/osf.json
@@ -113,6 +113,33 @@
             "md5": "8f75b95c0e47ae935d10745baefa2c49"
         }
     },
+    "tpl-civet": {
+        "v1": {
+            "civet41k": {
+                "url": [
+                    "mb37e",
+                    "601daffd84ecf800fe031868"
+                ],
+                "md5": "b27219c876464992e1b61da1c60d8d6e"
+            }
+        },
+        "v2": {
+            "civet41k": {
+                "url": [
+                    "mb37e",
+                    "601dafe77ad0a80119d9483c"
+                ],
+                "md5": "a47b015e471c6a800d236f107fda5b4a"
+            },
+            "civet164k": {
+                "url": [
+                    "mb37e",
+                    "601dafe87ad0a8011ad94938"
+                ],
+                "md5": "02537ea65d5366acd8de729022a34bab"
+            }
+        }
+    },
     "ds-connectomes": {
         "celegans": {
             "url": [

--- a/netneurotools/datasets/__init__.py
+++ b/netneurotools/datasets/__init__.py
@@ -6,12 +6,13 @@ __all__ = [
     'fetch_cammoun2012', 'fetch_pauli2018', 'fetch_fsaverage', 'fetch_conte69',
     'fetch_connectome', 'available_connectomes', 'fetch_vazquez_rodriguez2019',
     'fetch_mirchi2018', 'make_correlated_xy', 'fetch_schaefer2018',
-    'fetch_hcp_standards', 'fetch_voneconomo', 'fetch_mmpall'
+    'fetch_hcp_standards', 'fetch_voneconomo', 'fetch_mmpall', 'fetch_civet'
 ]
 
 from .fetchers import (fetch_cammoun2012, fetch_pauli2018, fetch_fsaverage,
                        fetch_conte69, fetch_connectome, available_connectomes,
                        fetch_vazquez_rodriguez2019, fetch_schaefer2018,
-                       fetch_hcp_standards, fetch_voneconomo, fetch_mmpall)
+                       fetch_hcp_standards, fetch_voneconomo, fetch_mmpall,
+                       fetch_civet)
 from .generators import (make_correlated_xy)
 from .mirchi import (fetch_mirchi2018)

--- a/netneurotools/datasets/fetchers.py
+++ b/netneurotools/datasets/fetchers.py
@@ -678,7 +678,7 @@ def fetch_mmpall(version='fslr32k', data_dir=None, url=None, resume=True,
     files = [(op.join(dataset_name, version, f), url, opts) for f in filenames]
     data = _fetch_files(data_dir, files=files, resume=resume, verbose=verbose)
 
-    return ANNOT(*data)
+    return SURFACE(*data)
 
 
 def fetch_voneconomo(data_dir=None, url=None, resume=True, verbose=1):

--- a/netneurotools/tests/test_civet.py
+++ b/netneurotools/tests/test_civet.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""
+For testing netneurotools.civet functionality
+"""
+
+import numpy as np
+import pytest
+
+from netneurotools import civet, datasets
+
+
+@pytest.fixture(scope='module')
+def civet_surf(tmp_path_factory):
+    tmpdir = str(tmp_path_factory.getbasetemp())
+    return datasets.fetch_civet(data_dir=tmpdir, verbose=0)['mid']
+
+
+def test_read_civet(civet_surf):
+    vertices, triangles = civet.read_civet(civet_surf.lh)
+    assert len(vertices) == 40962
+    assert len(triangles) == 81920
+    assert np.all(triangles.max(axis=0) < vertices.shape[0])
+
+
+def test_civet_to_freesurfer():
+    brainmap = np.random.rand(81924)
+    out = civet.civet_to_freesurfer(brainmap)
+    out2 = civet.civet_to_freesurfer(brainmap, method='linear')
+    assert out.shape[0] == out2.shape[0] == 81924
+
+    with pytest.raises(ValueError):
+        civet.civet_to_freesurfer(np.random.rand(10))

--- a/netneurotools/tests/test_datasets.py
+++ b/netneurotools/tests/test_datasets.py
@@ -183,6 +183,18 @@ def test_get_dataset_info(dset, expected):
         utils._get_dataset_info('notvalid')
 
 
+@pytest.mark.parametrize('version', [
+    'v1', 'v2'
+])
+def test_fetch_civet(tmpdir, version):
+    civet = datasets.fetch_civet(version=version, data_dir=tmpdir, verbose=0)
+    for key in ('mid', 'white'):
+        assert key in civet
+        for hemi in ('lh', 'rh'):
+            assert hasattr(civet[key], hemi)
+            assert os.path.isfile(getattr(civet[key], hemi))
+
+
 def test_get_data_dir(tmpdir):
     data_dir = utils._get_data_dir(tmpdir)
     assert os.path.isdir(data_dir)


### PR DESCRIPTION
Also adds a fetcher for the CIVET surfaces and a CIVET surface reader function.

We should be able to use this to map the CIVET-space stat maps to `fsaverage6` space pretty easily @justinehansen @liuzhenqi77 ! I checked with the glycolytic index maps @justinehansen had provided me and this returns identical results to the Matlab script :grin:

To Do:
- [x] Add tests for dataset fetcher
- [x] Add tests for CIVET -> FS conversion (might require adding a test dataset?)
- [x] Update documentation with `netneurotools.civet` module functionality