### PR TITLE
Add custom_aspect parameter to plot_point_brain.

### DIFF
--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -787,7 +787,7 @@ def plot_point_brain(data, coords, views=None, cbar=False, figsize=(4, 4.8),
         # make the actual scatterplot and update the view / aspect ratios
         col = ax.scatter(x, y, z, c=data, s=size, **opts)
         ax.view_init(*view)
-        # ax.axis('off')
+        ax.axis('off')
         scaling = np.array([ax.get_xlim(),
                             ax.get_ylim(),
                             ax.get_zlim()])

--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -741,6 +741,10 @@ def plot_point_brain(data, coords, views=None, custom_aspect=True, cbar=False,
         List specifying which views to use. Can be any of {'sagittal', 'sag',
         'coronal', 'cor', 'axial', 'ax'}. If not specified will use 'sagittal'
         and 'axial'. Default: None
+    custom_aspect: bool, optional
+        Whether to use a custom aspect ratio, specifically set to visualize
+        brain data, but that deforms the data, or automatically scale axes to
+        have an 'equal' aspect ratios. Default: True
     cbar : bool, optional
         Whether to also show colorbar. Default: False
     figsize : tuple, optional

--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -762,7 +762,6 @@ def plot_point_brain(data, coords, views=None, cbar=False, figsize=(4, 4.8),
                   coronal=(0, 90), cor=(0, 90))
 
     # coordinate space needs to be centered around zero for aspect ratio
-    coords = zscore(coords)
     x, y, z = coords[:, 0], coords[:, 1], coords[:, 2]
     if views is None:
         views = [_views[f] for f in ['sagittal', 'axial']]
@@ -789,10 +788,11 @@ def plot_point_brain(data, coords, views=None, cbar=False, figsize=(4, 4.8),
         # make the actual scatterplot and update the view / aspect ratios
         col = ax.scatter(x, y, z, c=data, s=size, **opts)
         ax.view_init(*view)
-        ax.axis('off')
-        ax.set(xlim=0.57 * np.array(ax.get_xlim()),
-               ylim=0.57 * np.array(ax.get_ylim()),
-               zlim=0.60 * np.array(ax.get_zlim()))
+        # ax.axis('off')
+        scaling = np.array([ax.get_xlim(),
+                            ax.get_ylim(),
+                            ax.get_zlim()])
+        ax.auto_scale_xyz(*[[np.min(scaling), np.max(scaling)]]*3)
     fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
 
     # add colorbar to axes

--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -800,10 +800,9 @@ def plot_point_brain(data, coords, views=None, custom_aspect=True, cbar=False,
 
         # if aspect is custom, manually set limits to the values we want
         if custom_aspect:
-            if view != (0, 90):
-                ax.set(xlim=0.665 * np.array(ax.get_xlim()),
-                       ylim=0.665 * np.array(ax.get_ylim()),
-                       zlim=0.70 * np.array(ax.get_zlim()))
+            ax.set(xlim=0.665 * np.array(ax.get_xlim()),
+                   ylim=0.665 * np.array(ax.get_ylim()),
+                   zlim=0.70 * np.array(ax.get_zlim()))
 
         # otherwise, automatically scale axes to have 'equal' aspect ratios
         else:

--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -726,7 +726,7 @@ def plot_fsvertex(data, *, order='lr', surf='pial', views='lat',
 
 
 def plot_point_brain(data, coords, views=None, views_orientation='vertical',
-                     cbar=False, figsize=(4, 4.8), robust=True, size=50,
+                     views_size=(4, 2.4), cbar=False, robust=True, size=50,
                      **kwargs):
     """
     Plots `data` as a cloud of points in 3D space based on specified `coords`
@@ -744,10 +744,10 @@ def plot_point_brain(data, coords, views=None, views_orientation='vertical',
     views_orientation: str, optional
         Orientation of the views. Can be either 'vertical' or 'horizontal'.
         Default: 'vertical'.
+    views_size : tuple, optional
+        Figure size of each view. Default: (4, 2.4)
     cbar : bool, optional
         Whether to also show colorbar. Default: False
-    figsize : tuple, optional
-        Figure size. Default: (4, 4.8)
     robust : bool, optional
         Whether to use robust calculation of `vmin` and `vmax` for color scale.
     size : int, optional
@@ -777,6 +777,7 @@ def plot_point_brain(data, coords, views=None, views_orientation='vertical',
         ncols, nrows = 1, len(views)
     elif views_orientation == 'horizontal':
         ncols, nrows = len(views), 1
+    figsize = (ncols * views_size[0], nrows * views_size[1])
 
     # create figure and axes (3d projections)
     fig, axes = plt.subplots(ncols=ncols, nrows=nrows,

--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -11,7 +11,6 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # noqa
 import nibabel as nib
 import numpy as np
-from scipy.stats import zscore
 
 from .freesurfer import FSIGNORE, _decode_list
 
@@ -792,7 +791,7 @@ def plot_point_brain(data, coords, views=None, cbar=False, figsize=(4, 4.8),
         scaling = np.array([ax.get_xlim(),
                             ax.get_ylim(),
                             ax.get_zlim()])
-        ax.auto_scale_xyz(*[[np.min(scaling), np.max(scaling)]]*3)
+        ax.auto_scale_xyz(*[[np.min(scaling), np.max(scaling)]] * 3)
     fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
 
     # add colorbar to axes

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ nilearn
 numpy>=1.16
 scikit-learn
 scipy>=1.4.0
-matplotlib >=3.3.0
+matplotlib>=3.3.0
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ nilearn
 numpy>=1.16
 scikit-learn
 scipy>=1.4.0
+matplotlib >=3.3.0
 tqdm

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -9,6 +9,7 @@ if [ -n "${OPTIONAL_DEPENDS}" ]; then
     for DEP in ${OPTIONAL_DEPENDS}; do
         if [ ${DEP} == "mayavi" ]; then
             python -m pip install numpy vtk
+            sudo apt update
             sudo apt-get install -y xvfb \
                                     x11-utils \
                                     mencoder \


### PR DESCRIPTION
The function plot_point_brain() sets the limits of the xyz axes with the following lines of code:

`        ax.set(xlim=0.57 * np.array(ax.get_xlim()),
               ylim=0.57 * np.array(ax.get_ylim()),
               zlim=0.60 * np.array(ax.get_zlim()))`

It also zscores the coordinates beforehand.

This might be problematic since these limits, being hard-coded, can lead to various bugs. For instance, if we use the coordinates of the Lausanne 1000 parcellation, some parcels are cropped out:

![image](https://user-images.githubusercontent.com/46877241/122461313-2bf2df00-cf81-11eb-8673-e6ef42c2a619.png)

To solve this particular bug, I modified those lines to 

`                ax.set(xlim=0.665 * np.array(ax.get_xlim()),
                       ylim=0.665 * np.array(ax.get_ylim()),
                       zlim=0.70 * np.array(ax.get_zlim()))`.

We now get this when we try to plot the Lausanne 1000 parcellation:

![image](https://user-images.githubusercontent.com/46877241/122461541-783e1f00-cf81-11eb-964a-75f940b1c635.png).

The parcels are no longer cropped out.

 Also, I personally enjoy visualizing my data such that the axes are automatically scaled to have "equal" aspect ratios, so I added a custom_aspect parameter to the function that can be set to False if the user wants. If this parameter is set to False, then the axes will be automatically scaled, which gives us:

![image](https://user-images.githubusercontent.com/46877241/122461872-e5ea4b00-cf81-11eb-8a39-3d70bd79b9ce.png).

This comes with the caveat that there is more space between the differerent views, and now the 3 brains are not perfectly aligned on top of one another. Also, the sagittal view is now much more elongated, which might be dissapointing if the user wants to plot a "toy" version of the brain that looks nice. So for this reason, this custom_aspect parameter is set to True by default (which gives us what we had before).

