### PR TITLE
[MNT] Import private namespaces if scipy > 1.8.0

### DIFF
--- a/netneurotools/freesurfer.py
+++ b/netneurotools/freesurfer.py
@@ -10,7 +10,7 @@ import warnings
 from nibabel.freesurfer import read_annot, read_geometry
 import numpy as np
 from scipy import sparse
-try:  #scipy >= 1.8.0
+try:  # scipy >= 1.8.0
     from scipy.ndimage._measurements import _stats, labeled_comprehension
 except ImportError:  # scipy < 1.8.0
     from scipy.ndimage.measurements import _stats, labeled_comprehension

--- a/netneurotools/freesurfer.py
+++ b/netneurotools/freesurfer.py
@@ -10,7 +10,10 @@ import warnings
 from nibabel.freesurfer import read_annot, read_geometry
 import numpy as np
 from scipy import sparse
-from scipy.ndimage.measurements import _stats, labeled_comprehension
+try:  #scipy >= 1.8.0
+    from scipy.ndimage._measurements import _stats, labeled_comprehension
+except ImportError:  # scipy < 1.8.0
+    from scipy.ndimage.measurements import _stats, labeled_comprehension
 from scipy.spatial.distance import cdist
 
 from .datasets import fetch_fsaverage

--- a/netneurotools/stats.py
+++ b/netneurotools/stats.py
@@ -9,7 +9,10 @@ import numpy as np
 from tqdm import tqdm
 from itertools import combinations
 from scipy import optimize, spatial, special, stats as sstats
-from scipy.stats.stats import _chk2_asarray
+try:  # scipy >= 1.8.0
+    from scipy.stats._stats_py import _chk2_asarray
+except ImportError:  # scipy < 1.8.0
+    from scipy.stats.stats import _chk2_asarray
 from sklearn.utils.validation import check_random_state
 from sklearn.linear_model import LinearRegression
 


### PR DESCRIPTION
This pull request fixes the import statements for functions in private namespaces in scipy. Private namespaces where renamed in scipy 1.8.0 to distinguish them from public ones (see [this issue](https://github.com/scipy/scipy/issues/14360)). I fixed the import statements appropriately and used a try/except statement so that the toolbox still works with scipy < 1.8.0