### PR TITLE
[ENH] Added some network metrics and overall maintenance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Print netneurotools version
         run: python -c "import netneurotools; print(netneurotools.__version__)" 
       - name: Run tests
-        run: pytest --doctest-modules --cov netneurotools --cov-report xml --juintxml=junit/test-results.xml --verbose --pyargs netneurotools
+        run: pytest --doctest-modules --cov=netneurotools --cov-report=xml --juintxml=junit/test-results.xml --verbose --pyargs netneurotools
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
         architecture: ['x64', 'x86']
         install: ['setup']
         check: ['test']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,98 +1,66 @@
 name: netneurotools tests
 
-on: [push, pull_request]
-
-defaults:
-  run:
-    shell: bash
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
-  check_skip:
+  check_style:
     runs-on: ubuntu-latest
-    outputs:
-      skip: ${{ steps.result_step.outputs.ci-skip }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - id: result_step
-        uses: mstachniuk/ci-skip@master
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
         with:
-          commit-filter: '[skip ci];[ci skip];[skip github]'
-          commit-filter-separator: ';'
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade pip
+            python -m pip install flake8
+      - name: Run style checks
+        run: flake8 netneurotools
 
-  checks:
-    needs: check_skip
-    if: ${{ needs.check_skip.outputs.skip == 'false' }}
+  run_tests:
+    needs: check_style
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        python-version: ['3.7', '3.8', '3.9']
-        architecture: ['x64', 'x86']
-        install: ['setup']
-        check: ['test']
-        optional-depends: ['']
-        include:
-          - os: ubuntu-latest
-            python-version: 3.8
-            install: setup
-            check: style
-            optional-depends: ''
-          - os: ubuntu-latest
-            python-version: 3.8
-            install: setup
-            check: doc
-            optional-depends: ''
-          - os: ubuntu-latest
-            python-version: 3.8
-            install: setup
-            check: test
-            optional-depends: 'numba pyqt5 mayavi pysurfer'
-          - os: ubuntu-latest
-            python-version: 3.8
-            install: sdist
-            check: test
-            optional-depends: ''
-          - os: ubuntu-latest
-            python-version: 3.8
-            install: wheel
-            check: test
-            optional-depends: ''
-        exclude:
-          - os: ubuntu-latest
-            architecture: x86
-          - os: macos-latest
-            architecture: x86
-    env:
-      INSTALL_TYPE: ${{ matrix.install }}
-      CHECK_TYPE: ${{ matrix.check }}
-      OPTIONAL_DEPENDS: ${{ matrix.optional-depends }}
+        os: ['ubuntu-latest']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies
-        run: ./tools/install_dependencies.sh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pytest-cov
+          python -m pip install -r requirements.txt
       - name: Install netneurotools
-        run: ./tools/install_package.sh
+        run: python -m pip install -e .
+      - name: Print netneurotools version
+        run: python -c "import netneurotools; print(netneurotools.__version__)" 
       - name: Run tests
-        run: ./tools/run_checks.sh
-      - uses: codecov/codecov-action@v1
+        run: pytest --doctest-modules --cov netneurotools --cov-report xml --juintxml=junit/test-results.xml --verbose --pyargs netneurotools
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
         with:
-          file: for_testing/coverage.xml
-        if: ${{ always() }}
+          file: coverage.xml
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}
-          path: for_testing/test-results.xml
-        if: ${{ always() && matrix.check == 'test' }}
+          path: junit/test-results.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Print netneurotools version
         run: python -c "import netneurotools; print(netneurotools.__version__)" 
       - name: Run tests
-        run: pytest --doctest-modules --cov=netneurotools --cov-report=xml --juintxml=junit/test-results.xml --verbose --pyargs netneurotools
+        run: pytest --doctest-modules --cov=netneurotools --cov-report=xml --junitxml=junit/test-results.xml --verbose --pyargs netneurotools
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ usage in the `Network Neuroscience Lab <netneurolab.github.io/>`_, housed in
 the `Brain Imaging Centre <https://www.mcgill.ca/bic/home>`_ at
 `McGill University <https://www.mcgill.ca/>`_.
 
-.. image:: https://travis-ci.org/netneurolab/netneurotools.svg?branch=master
-   :target: https://travis-ci.org/netneurolab/netneurotools
+.. image:: https://github.com/netneurolab/netneurotools/actions/workflows/tests.yml/badge.svg
+   :target: https://github.com/netneurolab/netneurotools/actions
 .. image:: https://codecov.io/gh/netneurolab/netneurotools/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/netneurolab/netneurotools
 .. image:: https://readthedocs.org/projects/netneurotools/badge/?version=latest

--- a/README.rst
+++ b/README.rst
@@ -15,13 +15,48 @@ the `Brain Imaging Centre <https://www.mcgill.ca/bic/home>`_ at
 .. image:: https://img.shields.io/badge/License-BSD%203--Clause-blue.svg
    :target: https://opensource.org/licenses/BSD-3-Clause
 
-.. _usage:
+.. _installation:
 
-Usage
------
+Installation
+------------
+
+Install directly from PyPi with :code:`pip install netneurotools` or install the main branch with
+
+.. code-block:: bash
+
+    git clone https://github.com/netneurolab/netneurotools.git
+    cd netneurotools
+    pip install .
+
+.. _features:
+
+Features
+--------
+
+*  Network neuroscience metrics: up-to-date and optimized
+
+   *  Network communication
+   *  Null networks
+
+*  Brain plotting functions: easy to use and customize
+
+   *  Surface visualization 
+      `plot_fsaverage <https://netneurotools.readthedocs.io/en/latest/generated/netneurotools.plotting.plot_fsaverage.html>`_ 
+      and `plot_fslr <https://netneurotools.readthedocs.io/en/latest/generated/netneurotools.plotting.plot_fslr.html>`_
+   *  3D point brain `plot_point_brain <https://netneurotools.readthedocs.io/en/latest/generated/netneurotools.plotting.plot_point_brain.html>`_
+   *  Sorted communities `plot_mod_heatmap <https://netneurotools.readthedocs.io/en/latest/generated/netneurotools.plotting.plot_mod_heatmap.html>`_
+
+*  Statistics functions
+
+   *  Dominance analysis `get_dominance_stats <https://netneurotools.readthedocs.io/en/latest/generated/netneurotools.stats.get_dominance_stats.html>`_
+
+*  Fetchers for common datasets
+
+*  Utilities for working with FreeSurfer and CIVET
+
 
 Check out our `documentation <https://netneurotools.readthedocs.io/en/latest>`_
-for information on how to install and use ``netneurotools``!
+for more information!
 
 .. _development:
 

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,6 +1,6 @@
 /* wide form */
 .wy-nav-content {
-   max-width: 1200px;
+   max-width: 1200px !important;
 }
 
 /* override table width restrictions */

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,3 +1,8 @@
+/* wide form */
+.wy-nav-content {
+   max-width: 1200px;
+}
+
 /* override table width restrictions */
 @media screen and (min-width: 767px) {
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,6 +28,7 @@ Python Reference API
    threshold_network
    binarize_network
    match_length_degree_distribution
+   randmio_und
 
 .. _ref_modularity:
 
@@ -142,6 +143,13 @@ Python Reference API
    rich_feeder_peripheral
    navigation_wu
    get_navigation_path_length
+   search_information
+   path_transitivity
+   flow_graph
+   mean_first_passage_time
+   diffusion_efficiency
+   resource_efficiency_bin
+   matching_ind_und
 
 .. _ref_datasets:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,10 +104,11 @@ htmlhelp_basename = 'netneurotoolsdoc'
 # -- Extension configuration -------------------------------------------------
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'matplotlib': ('https://matplotlib.org', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'matplotlib': ('https://matplotlib.org/stable', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'sklearn': ('https://scikit-learn.org/stable', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
 }
 
 doctest_global_setup = """\

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -r ../requirements.txt
-sphinx>=1.2
+sphinx>=2.0, <7.0.0
 sphinx_rtd_theme
 sphinx-gallery
 pillow

--- a/netneurotools/civet.py
+++ b/netneurotools/civet.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Functions for working with CIVET data (ugh)
-"""
+"""Functions for working with CIVET data (ugh)."""
 
 import nibabel as nib
 import numpy as np
@@ -17,7 +15,7 @@ _MNI305to152 = np.array([[0.9975, -0.0073, 0.0176, -0.0429],
 
 def read_civet(fname):
     """
-    Reads a CIVET-style .obj geometry file
+    Read a CIVET-style .obj geometry file.
 
     Parameters
     ----------
@@ -29,7 +27,6 @@ def read_civet(fname):
     vertices : (N, 3)
     triangles : (T, 3)
     """
-
     k, polygons = 0, []
     with open(fname, 'r') as src:
         n_vert = int(src.readline().split()[6])
@@ -52,7 +49,7 @@ def civet_to_freesurfer(brainmap, surface='mid', version='v1',
                         freesurfer='fsaverage6', method='nearest',
                         data_dir=None):
     """
-    Projects `brainmap` in CIVET space to `freesurfer` fsaverage space
+    Project `brainmap` in CIVET space to `freesurfer` fsaverage space.
 
     Uses a nearest-neighbor projection based on the geometry of the vertices
 
@@ -81,7 +78,6 @@ def civet_to_freesurfer(brainmap, surface='mid', version='v1',
     data : np.ndarray
         Provided `brainmap` mapped to FreeSurfer
     """
-
     brainmap = np.asarray(brainmap)
     densities = (81924, 327684)
     n_vert = brainmap.shape[0]

--- a/netneurotools/cluster.py
+++ b/netneurotools/cluster.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Functions for clustering and working with cluster solutions
-"""
+"""Functions for clustering and working with cluster solutions."""
 
 import bct
 import numpy as np
@@ -12,7 +10,7 @@ from sklearn.utils.validation import check_random_state
 
 def _get_relabels(c1, c2):
     """
-    Finds mapping of labels from `c1` to `c2`
+    Find mapping of labels from `c1` to `c2`.
 
     Parameters
     ----------
@@ -46,7 +44,7 @@ def _get_relabels(c1, c2):
 
 def match_cluster_labels(source, target):
     """
-    Aligns cluster labels in `source` to those in `target`
+    Align cluster labels in `source` to those in `target`.
 
     Uses :func:`scipy.optimize.linear_sum_assignment` to match solutions. If
     `source` has fewer clusters than `target` the returned assignments may be
@@ -91,7 +89,6 @@ def match_cluster_labels(source, target):
     >>> cluster.match_cluster_labels(b, a)
     array([0, 0, 0, 2, 2, 2, 2, 2, 2, 2])
     """
-
     # try and match the source to target
     src, tar = _get_relabels(source, target)
 
@@ -112,7 +109,7 @@ def match_cluster_labels(source, target):
 
 def match_assignments(assignments, target=None, seed=None):
     """
-    Re-labels clusters in columns of `assignments` to best match `target`
+    Re-label clusters in columns of `assignments` to best match `target`.
 
     Uses :func:`~.cluster.match_cluster_labels` to align cluster assignments.
 
@@ -192,7 +189,6 @@ def match_assignments(assignments, target=None, seed=None):
            [1, 2, 2],
            [1, 2, 2]])
     """
-
     assignments = np.asarray(assignments).copy()
 
     # pick a random assignment with the lowest # of clusters as "target"
@@ -220,7 +216,7 @@ def match_assignments(assignments, target=None, seed=None):
 def reorder_assignments(assignments, consensus=None, col_sort=True,
                         row_sort=True, return_index=True, seed=None):
     """
-    Relabels and reorders rows / columns of `assignments` to "look better"
+    Relabel and reorders rows / columns of `assignments` to "look better".
 
     Relabels cluster solutions in `assignments` so that distinct clustering
     solutions have similar cluster labels. Then, swaps columns of `assignments`
@@ -254,8 +250,7 @@ def reorder_assignments(assignments, consensus=None, col_sort=True,
     """
 
     def _reorder_rows(arr):
-        """ Returns indices of rows in `arr` after hierarchical clustering
-        """
+        """Return indices of rows in `arr` after hierarchical clustering."""
         link = hierarchy.linkage(arr, method='average', metric='hamming')
         return hierarchy.dendrogram(link, no_plot=True)['leaves']
 
@@ -317,7 +312,7 @@ def reorder_assignments(assignments, consensus=None, col_sort=True,
 def find_consensus(assignments, null_func=np.mean, return_agreement=False,
                    seed=None):
     """
-    Finds consensus clustering labels from cluster solutions in `assignments`
+    Find consensus clustering labels from cluster solutions in `assignments`.
 
     Parameters
     ----------
@@ -348,7 +343,6 @@ def find_consensus(assignments, null_func=np.mean, return_agreement=False,
     structure in networks. Chaos: An Interdisciplinary Journal of Nonlinear
     Science, 23(1), 013142.
     """
-
     rs = check_random_state(seed)
     samp, comm = assignments.shape
 

--- a/netneurotools/colors.py
+++ b/netneurotools/colors.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Useful colormaps
-"""
+"""Useful colormaps."""
 
 from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 
@@ -90,16 +88,12 @@ dinosaur = LinearSegmentedColormap.from_list(
 
 
 def available_cmaps():
-    """ Returns list of available colormaps in module
-    """
-
+    """Return list of available colormaps in module."""
     return __all__.copy()
 
 
 def _register_cmaps():
-    """ Registers all colormaps in module so they are accessible via matplotlib
-    """
-
+    """Register all colormaps in module so they are accessible via matplotlib."""
     from matplotlib.cm import register_cmap
 
     for cmap in __all__:

--- a/netneurotools/datasets/__init__.py
+++ b/netneurotools/datasets/__init__.py
@@ -1,6 +1,4 @@
-"""
-Functions for fetching and generating datasets
-"""
+"""Functions for fetching and generating datasets."""
 
 __all__ = [
     'fetch_cammoun2012', 'fetch_pauli2018', 'fetch_fsaverage', 'fetch_conte69',

--- a/netneurotools/datasets/fetchers.py
+++ b/netneurotools/datasets/fetchers.py
@@ -648,7 +648,8 @@ def fetch_hcp_standards(data_dir=None, url=None, resume=True, verbose=1):
         Filepath to standard_mesh_atlases directory
     """
     if url is None:
-        url = 'http://brainvis.wustl.edu/workbench/standard_mesh_atlases.zip'
+        url = 'https://web.archive.org/web/20220121035833/' + \
+              'http://brainvis.wustl.edu/workbench/standard_mesh_atlases.zip'
     dataset_name = 'standard_mesh_atlases'
     data_dir = _get_data_dir(data_dir=data_dir)
     opts = {

--- a/netneurotools/datasets/fetchers.py
+++ b/netneurotools/datasets/fetchers.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Functions for fetching datasets from the internet
-"""
+"""Functions for fetching datasets from the internet."""
 
 from collections import namedtuple
 import itertools
@@ -22,7 +20,7 @@ SURFACE = namedtuple('Surface', ('lh', 'rh'))
 def fetch_cammoun2012(version='MNI152NLin2009aSym', data_dir=None, url=None,
                       resume=True, verbose=1):
     """
-    Downloads files for Cammoun et al., 2012 multiscale parcellation
+    Download files for Cammoun et al., 2012 multiscale parcellation.
 
     Parameters
     ----------
@@ -65,7 +63,6 @@ def fetch_cammoun2012(version='MNI152NLin2009aSym', data_dir=None, url=None,
     -----
     License: https://raw.githubusercontent.com/LTS5/cmp/master/COPYRIGHT
     """
-
     if version == 'surface':
         warnings.warn('Providing `version="surface"` is deprecated and will '
                       'be removed in a future release. For consistent '
@@ -148,7 +145,7 @@ def fetch_cammoun2012(version='MNI152NLin2009aSym', data_dir=None, url=None,
 
 def fetch_conte69(data_dir=None, url=None, resume=True, verbose=1):
     """
-    Downloads files for Van Essen et al., 2012 Conte69 template
+    Download files for Van Essen et al., 2012 Conte69 template.
 
     Parameters
     ----------
@@ -185,7 +182,6 @@ def fetch_conte69(data_dir=None, url=None, resume=True, verbose=1):
     -----
     License: ???
     """
-
     dataset_name = 'tpl-conte69'
     keys = ['midthickness', 'inflated', 'vinflated']
 
@@ -219,7 +215,7 @@ def fetch_conte69(data_dir=None, url=None, resume=True, verbose=1):
 
 def fetch_yerkes19(data_dir=None, url=None, resume=None, verbose=1):
     """
-    Downloads files for Donahue et al., 2016 Yerkes19 template
+    Download files for Donahue et al., 2016 Yerkes19 template.
 
     Parameters
     ----------
@@ -257,7 +253,6 @@ def fetch_yerkes19(data_dir=None, url=None, resume=None, verbose=1):
     -----
     License: ???
     """
-
     dataset_name = 'tpl-yerkes19'
     keys = ['midthickness', 'inflated', 'vinflated']
 
@@ -288,7 +283,7 @@ def fetch_yerkes19(data_dir=None, url=None, resume=None, verbose=1):
 
 def fetch_pauli2018(data_dir=None, url=None, resume=True, verbose=1):
     """
-    Downloads files for Pauli et al., 2018 subcortical parcellation
+    Download files for Pauli et al., 2018 subcortical parcellation.
 
     Parameters
     ----------
@@ -321,7 +316,6 @@ def fetch_pauli2018(data_dir=None, url=None, resume=True, verbose=1):
     -----
     License: CC-BY Attribution 4.0 International
     """
-
     dataset_name = 'atl-pauli2018'
     keys = ['probabilistic', 'deterministic', 'info']
 
@@ -342,7 +336,7 @@ def fetch_pauli2018(data_dir=None, url=None, resume=True, verbose=1):
 def fetch_fsaverage(version='fsaverage', data_dir=None, url=None, resume=True,
                     verbose=1):
     """
-    Downloads files for fsaverage FreeSurfer template
+    Download files for fsaverage FreeSurfer template.
 
     Parameters
     ----------
@@ -368,12 +362,7 @@ def fetch_fsaverage(version='fsaverage', data_dir=None, url=None, resume=True,
         Dictionary-like object with keys ['surf'] where corresponding values
         are length-2 lists downloaded template files (each list composed of
         files for the left and right hemisphere).
-
-    References
-    ----------
-
     """
-
     versions = [
         'fsaverage', 'fsaverage3', 'fsaverage4', 'fsaverage5', 'fsaverage6'
     ]
@@ -415,21 +404,20 @@ def fetch_fsaverage(version='fsaverage', data_dir=None, url=None, resume=True,
 
 def available_connectomes():
     """
-    Lists datasets available via :func:`~.fetch_connectome`
+    List datasets available via :func:`~.fetch_connectome`.
 
     Returns
     -------
     datasets : list of str
         List of available datasets
     """
-
     return sorted(_get_dataset_info('ds-connectomes').keys())
 
 
 def fetch_connectome(dataset, data_dir=None, url=None, resume=True,
                      verbose=1):
     """
-    Downloads files from multi-species connectomes
+    Download files from multi-species connectomes.
 
     Parameters
     ----------
@@ -464,7 +452,6 @@ def fetch_connectome(dataset, data_dir=None, url=None, resume=True,
     ----------
     See `ref` key of returned dictionary object for relevant dataset reference
     """
-
     if dataset not in available_connectomes():
         raise ValueError('Provided dataset {} not available; must be one of {}'
                          .format(dataset, available_connectomes()))
@@ -502,7 +489,7 @@ def fetch_connectome(dataset, data_dir=None, url=None, resume=True,
 def fetch_vazquez_rodriguez2019(data_dir=None, url=None, resume=True,
                                 verbose=1):
     """
-    Downloads files from Vazquez-Rodriguez et al., 2019, PNAS
+    Download files from Vazquez-Rodriguez et al., 2019, PNAS.
 
     Parameters
     ----------
@@ -529,7 +516,6 @@ def fetch_vazquez_rodriguez2019(data_dir=None, url=None, resume=True,
     ----------
     See `ref` key of returned dictionary object for relevant dataset reference
     """
-
     dataset_name = 'ds-vazquez_rodriguez2019'
 
     data_dir = _get_data_dir(data_dir=data_dir)
@@ -557,7 +543,7 @@ def fetch_vazquez_rodriguez2019(data_dir=None, url=None, resume=True,
 def fetch_schaefer2018(version='fsaverage', data_dir=None, url=None,
                        resume=True, verbose=1):
     """
-    Downloads FreeSurfer .annot files for Schaefer et al., 2018 parcellation
+    Download FreeSurfer .annot files for Schaefer et al., 2018 parcellation.
 
     Parameters
     ----------
@@ -594,7 +580,6 @@ def fetch_schaefer2018(version='fsaverage', data_dir=None, url=None,
     -----
     License: https://github.com/ThomasYeoLab/CBIG/blob/master/LICENSE.md
     """
-
     versions = ['fsaverage', 'fsaverage5', 'fsaverage6', 'fslr32k']
     if version not in versions:
         raise ValueError('The version of Schaefer et al., 2018 parcellation '
@@ -640,7 +625,7 @@ def fetch_schaefer2018(version='fsaverage', data_dir=None, url=None,
 
 def fetch_hcp_standards(data_dir=None, url=None, resume=True, verbose=1):
     """
-    Fetches HCP standard mesh atlases for converting between FreeSurfer and HCP
+    Fetch HCP standard mesh atlases for converting between FreeSurfer and HCP.
 
     Parameters
     ----------
@@ -682,7 +667,7 @@ def fetch_hcp_standards(data_dir=None, url=None, resume=True, verbose=1):
 def fetch_mmpall(version='fslr32k', data_dir=None, url=None, resume=True,
                  verbose=1):
     """
-    Downloads .label.gii files for Glasser et al., 2016 MMPAll atlas
+    Download .label.gii files for Glasser et al., 2016 MMPAll atlas.
 
     Parameters
     ----------
@@ -719,7 +704,6 @@ def fetch_mmpall(version='fslr32k', data_dir=None, url=None, resume=True,
     License: https://www.humanconnectome.org/study/hcp-young-adult/document/
     wu-minn-hcp-consortium-open-access-data-use-terms
     """
-
     versions = ['fslr32k']
     if version not in versions:
         raise ValueError('The version of Glasser et al., 2016 parcellation '
@@ -752,7 +736,7 @@ def fetch_mmpall(version='fslr32k', data_dir=None, url=None, resume=True,
 
 def fetch_voneconomo(data_dir=None, url=None, resume=True, verbose=1):
     """
-    Fetches von-Economo Koskinas probabilistic FreeSurfer atlas
+    Fetch von-Economo Koskinas probabilistic FreeSurfer atlas.
 
     Parameters
     ----------
@@ -784,7 +768,6 @@ def fetch_voneconomo(data_dir=None, url=None, resume=True, verbose=1):
     -----
     License: CC-BY-NC-SA 4.0
     """
-
     dataset_name = 'atl-voneconomo_koskinas'
     keys = ['gcs', 'ctab', 'info']
 
@@ -811,7 +794,7 @@ def fetch_voneconomo(data_dir=None, url=None, resume=True, verbose=1):
 def fetch_civet(density='41k', version='v1', data_dir=None, url=None,
                 resume=True, verbose=1):
     """
-    Fetches CIVET surface files
+    Fetch CIVET surface files.
 
     Parameters
     ----------
@@ -852,7 +835,6 @@ def fetch_civet(density='41k', version='v1', data_dir=None, url=None,
     -----
     License: https://github.com/aces/CIVET_Full_Project/blob/master/LICENSE
     """
-
     densities = ['41k', '164k']
     if density not in densities:
         raise ValueError('The density of CIVET requested "{}" does not exist. '

--- a/netneurotools/datasets/generators.py
+++ b/netneurotools/datasets/generators.py
@@ -1,8 +1,6 @@
 
 # -*- coding: utf-8 -*-
-"""
-Functions for making "random" datasets
-"""
+"""Functions for making "random" datasets."""
 
 import numpy as np
 from sklearn.utils.validation import check_random_state
@@ -10,7 +8,7 @@ from sklearn.utils.validation import check_random_state
 
 def make_correlated_xy(corr=0.85, size=10000, seed=None, tol=0.001):
     """
-    Generates random vectors that are correlated to approximately `corr`
+    Generate random vectors that are correlated to approximately `corr`.
 
     Parameters
     ----------
@@ -61,7 +59,6 @@ def make_correlated_xy(corr=0.85, size=10000, seed=None, tol=0.001):
            [0.50965273, 1.        , 0.01089107],
            [0.30235686, 0.01089107, 1.        ]])
     """
-
     rs = check_random_state(seed)
 
     # no correlations outside [-1, 1] bounds

--- a/netneurotools/datasets/mirchi.py
+++ b/netneurotools/datasets/mirchi.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Code for re-generating results from Mirchi et al., 2018 (SCAN)
-"""
+"""Code for re-generating results from Mirchi et al., 2018 (SCAN)."""
 
 import os
 from urllib.request import HTTPError, urlopen
@@ -75,14 +73,13 @@ PANAS = {  # specification for creation of PANAS subscales for item scores
 
 def _get_fc(data_dir=None, resume=True, verbose=1):
     """
-    Gets functional connections from MyConnectome parcelled time series data
+    Get functional connections from MyConnectome parcelled time series data.
 
     Returns
     -------
     fc : (73, 198135) numpy.ndarray
         Functional connections (lower triangle)
     """
-
     # download time series data for all sessions
     ts = []
     for ses in SESSIONS:
@@ -104,7 +101,7 @@ def _get_fc(data_dir=None, resume=True, verbose=1):
 
 def _get_panas(data_dir=None, resume=True, verbose=1):
     """
-    Gets PANAS subscales from MyConnectome behavioral data
+    Get PANAS subscales from MyConnectome behavioral data.
 
     Returns
     -------
@@ -112,7 +109,6 @@ def _get_panas(data_dir=None, resume=True, verbose=1):
         Where keys are PANAS subscales names and values are session-level
         composite measures
     """
-
     from numpy.lib.recfunctions import structured_to_unstructured as stu
 
     # download behavioral data
@@ -140,7 +136,7 @@ def _get_panas(data_dir=None, resume=True, verbose=1):
 
 def fetch_mirchi2018(data_dir=None, resume=True, verbose=1):
     """
-    Downloads (and creates) dataset for replicating Mirchi et al., 2018, SCAN
+    Download (and creates) dataset for replicating Mirchi et al., 2018, SCAN.
 
     Parameters
     ----------
@@ -157,7 +153,6 @@ def fetch_mirchi2018(data_dir=None, resume=True, verbose=1):
     Y : (73, 13) numpy.ndarray
         PANAS subscales from MyConnectome behavioral data
     """
-
     data_dir = os.path.join(_get_data_dir(data_dir=data_dir), 'ds-mirchi2018')
     os.makedirs(data_dir, exist_ok=True)
 

--- a/netneurotools/datasets/utils.py
+++ b/netneurotools/datasets/utils.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Utilites for loading / creating datasets
-"""
+"""Utilites for loading / creating datasets."""
 
 import json
 import os
@@ -10,7 +8,7 @@ from pkg_resources import resource_filename
 
 def _osfify_urls(data):
     """
-    Formats `data` object with OSF API URL
+    Format `data` object with OSF API URL.
 
     Parameters
     ----------
@@ -22,7 +20,6 @@ def _osfify_urls(data):
     data : object
         Input data with all `url` dict keys formatted
     """
-
     OSF_API = "https://files.osf.io/v1/resources/{}/providers/osfstorage/{}"
 
     if isinstance(data, str):
@@ -46,7 +43,7 @@ with open(resource_filename('netneurotools', 'data/osf.json')) as src:
 
 def _get_dataset_info(name):
     """
-    Returns url and MD5 checksum for dataset `name`
+    Return url and MD5 checksum for dataset `name`.
 
     Parameters
     ----------
@@ -60,7 +57,6 @@ def _get_dataset_info(name):
     md5 : str
         MD5 checksum for file downloade from `url`
     """
-
     try:
         return OSF_RESOURCES[name]
     except KeyError:
@@ -70,7 +66,7 @@ def _get_dataset_info(name):
 
 def _get_data_dir(data_dir=None):
     """
-    Gets path to netneurotools data directory
+    Get path to netneurotools data directory.
 
     Parameters
     ----------
@@ -84,7 +80,6 @@ def _get_data_dir(data_dir=None):
     data_dir : str
         Path to use as data directory
     """
-
     if data_dir is None:
         data_dir = os.environ.get('NNT_DATA', os.path.join('~', 'nnt-data'))
     data_dir = os.path.expanduser(data_dir)

--- a/netneurotools/freesurfer.py
+++ b/netneurotools/freesurfer.py
@@ -325,8 +325,8 @@ def vertices_to_parcels(data, *, lhannot, rhannot, drop=None):
         to parcels defined in `netneurotools.freesurfer.FSIGNORE` will be
         removed. Default: None
 
-    Reurns
-    ------
+    Returns
+    -------
     reduced : numpy.ndarray
         Parcellated `data`, without regions specified in `drop`
     """

--- a/netneurotools/freesurfer.py
+++ b/netneurotools/freesurfer.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Functions for working with FreeSurfer data and parcellations
-"""
+"""Functions for working with FreeSurfer data and parcellations."""
 
 import os
 import os.path as op
@@ -30,7 +28,7 @@ def apply_prob_atlas(subject_id, gcs, hemi, *, orig='white', annot=None,
                      ctab=None, subjects_dir=None, use_cache=True,
                      quiet=False):
     """
-    Creates an annotation file for `subject_id` by applying atlas in `gcs`
+    Create an annotation file for `subject_id` by applying atlas in `gcs`.
 
     Runs subprocess calling FreeSurfer's "mris_ca_label" function; as such,
     FreeSurfer must be installed and accesible on the local system path.
@@ -67,7 +65,6 @@ def apply_prob_atlas(subject_id, gcs, hemi, *, orig='white', annot=None,
     annot : str
         Path to generated annotation file
     """
-
     cmd = 'mris_ca_label {opts}{subject_id} {hemi} {hemi}.sphere.reg ' \
           '{gcs} {annot}'
 
@@ -109,16 +106,14 @@ def apply_prob_atlas(subject_id, gcs, hemi, *, orig='white', annot=None,
 
 
 def _decode_list(vals):
-    """ List decoder
-    """
-
+    """List decoder."""
     return [val.decode() if hasattr(val, 'decode') else val for val in vals]
 
 
 def find_parcel_centroids(*, lhannot, rhannot, method='surface',
                           version='fsaverage', surf='sphere', drop=None):
     """
-    Returns vertex coords corresponding to centroids of parcels in annotations
+    Return vertex coords corresponding to centroids of parcels in annotations.
 
     Note that using any other `surf` besides the default of 'sphere' may result
     in centroids that are not directly within the parcels themselves due to
@@ -177,7 +172,6 @@ def find_parcel_centroids(*, lhannot, rhannot, method='surface',
        more time-consuming than the other two methods, especially for
        high-resolution meshes.
     """
-
     methods = ['average', 'surface', 'geodesic']
     if method not in methods:
         raise ValueError('Provided method for centroid calculation {} is '
@@ -213,7 +207,7 @@ def find_parcel_centroids(*, lhannot, rhannot, method='surface',
 
 def _geodesic_parcel_centroid(vertices, faces, inds):
     """
-    Calculates parcel centroids based on surface distance
+    Calculate parcel centroids based on surface distance.
 
     Parameters
     ----------
@@ -229,7 +223,6 @@ def _geodesic_parcel_centroid(vertices, faces, inds):
     roi : (3,) numpy.ndarray
         Vertex corresponding to centroid of parcel
     """
-
     mask = np.ones(len(vertices), dtype=bool)
     mask[inds] = False
     mat = make_surf_graph(vertices, faces, mask=mask)
@@ -244,7 +237,7 @@ def _geodesic_parcel_centroid(vertices, faces, inds):
 
 def parcels_to_vertices(data, *, lhannot, rhannot, drop=None):
     """
-    Projects parcellated `data` to vertices defined in annotation files
+    Project parcellated `data` to vertices defined in annotation files.
 
     Assigns np.nan to all ROIs in `drop`
 
@@ -269,7 +262,6 @@ def parcels_to_vertices(data, *, lhannot, rhannot, drop=None):
     projected : numpy.ndarray
         Vertex-level data
     """
-
     if drop is None:
         drop = FSIGNORE
     drop = _decode_list(drop)
@@ -314,7 +306,7 @@ def parcels_to_vertices(data, *, lhannot, rhannot, drop=None):
 
 def vertices_to_parcels(data, *, lhannot, rhannot, drop=None):
     """
-    Reduces vertex-level `data` to parcels defined in annotation files
+    Reduce vertex-level `data` to parcels defined in annotation files.
 
     Takes average of vertices within each parcel, excluding np.nan values
     (i.e., np.nanmean). Assigns np.nan to parcels for which all vertices are
@@ -338,7 +330,6 @@ def vertices_to_parcels(data, *, lhannot, rhannot, drop=None):
     reduced : numpy.ndarray
         Parcellated `data`, without regions specified in `drop`
     """
-
     if drop is None:
         drop = FSIGNORE
     drop = _decode_list(drop)
@@ -403,7 +394,7 @@ def vertices_to_parcels(data, *, lhannot, rhannot, drop=None):
 
 def _get_fsaverage_coords(version='fsaverage', surface='sphere'):
     """
-    Gets vertex coordinates for specified `surface` of fsaverage `version`
+    Get vertex coordinates for specified `surface` of fsaverage `version`.
 
     Parameters
     ----------
@@ -421,7 +412,6 @@ def _get_fsaverage_coords(version='fsaverage', surface='sphere'):
         Array denoting hemisphere designation of entries in `coords`, where
         `hemiid=0` denotes the left and `hemiid=1` the right hemisphere
     """
-
     # get coordinates and hemisphere designation for spin generation
     lhsphere, rhsphere = fetch_fsaverage(version)[surface]
     coords, hemi = [], []
@@ -435,7 +425,7 @@ def _get_fsaverage_coords(version='fsaverage', surface='sphere'):
 def _get_fsaverage_spins(version='fsaverage', spins=None, n_rotate=1000,
                          **kwargs):
     """
-    Generates spatial permutation resamples for fsaverage `version`
+    Generate spatial permutation resamples for fsaverage `version`.
 
     If `spins` are provided then performs checks to confirm they are valid
 
@@ -459,11 +449,10 @@ def _get_fsaverage_spins(version='fsaverage', spins=None, n_rotate=1000,
         Keyword arguments passed to `netneurotools.stats.gen_spinsamples`
 
     Returns
-    --------
+    -------
     spins : (N, S) numpy.ndarray
         Resampling array
     """
-
     if spins is None:
         coords, hemiid = _get_fsaverage_coords(version, 'sphere')
         spins = gen_spinsamples(coords, hemiid, n_rotate=n_rotate,
@@ -485,7 +474,7 @@ def _get_fsaverage_spins(version='fsaverage', spins=None, n_rotate=1000,
 def spin_data(data, *, lhannot, rhannot, version='fsaverage', n_rotate=1000,
               spins=None, drop=None, verbose=False, **kwargs):
     """
-    Projects parcellated `data` to surface, rotates, and re-parcellates
+    Project parcellated `data` to surface, rotates, and re-parcellates.
 
     Projection to the surface uses `{lh,rh}annot` files. Rotation uses vertex
     coordinates from the specified fsaverage `version` and relies on
@@ -531,7 +520,6 @@ def spin_data(data, *, lhannot, rhannot, version='fsaverage', n_rotate=1000,
         for every rotation in `spinsamples`. Only provided if `return_cost` is
         True.
     """
-
     if drop is None:
         drop = FSIGNORE
 
@@ -571,7 +559,7 @@ def spin_data(data, *, lhannot, rhannot, version='fsaverage', n_rotate=1000,
 def spin_parcels(*, lhannot, rhannot, version='fsaverage', n_rotate=1000,
                  spins=None, drop=None, verbose=False, **kwargs):
     """
-    Rotates parcels in `{lh,rh}annot` and re-assigns based on maximum overlap
+    Rotate parcels in `{lh,rh}annot` and re-assigns based on maximum overlap.
 
     Vertex labels are rotated with :func:`netneurotools.stats.gen_spinsamples`
     and a new label is assigned to each *parcel* based on the region maximally
@@ -621,8 +609,7 @@ def spin_parcels(*, lhannot, rhannot, version='fsaverage', n_rotate=1000,
     """
 
     def overlap(vals):
-        """ Returns most common non-negative value in `vals`; -1 if all neg
-        """
+        """Return most common non-negative value in `vals`; -1 if all neg."""
         vals = np.asarray(vals)
         vals, counts = np.unique(vals[vals > 0], return_counts=True)
         try:

--- a/netneurotools/freesurfer.py
+++ b/netneurotools/freesurfer.py
@@ -225,7 +225,7 @@ def _geodesic_parcel_centroid(vertices, faces, inds):
         Indices of `vertices` that belong to parcel
 
     Returns
-    --------
+    -------
     roi : (3,) numpy.ndarray
         Vertex corresponding to centroid of parcel
     """
@@ -264,8 +264,8 @@ def parcels_to_vertices(data, *, lhannot, rhannot, drop=None):
         not specified, parcels defined in `netneurotools.freesurfer.FSIGNORE`
         are assumed to not be present. Default: None
 
-    Reurns
-    ------
+    Returns
+    -------
     projected : numpy.ndarray
         Vertex-level data
     """

--- a/netneurotools/metrics.py
+++ b/netneurotools/metrics.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-Functions for calculating network metrics. Uses naming conventions adopted
-from the Brain Connectivity Toolbox (https://sites.google.com/site/bctnet/).
+Functions for calculating network metrics.
+
+Uses naming conventions adopted from the Brain Connectivity
+Toolbox (https://sites.google.com/site/bctnet/).
 """
 
 import itertools
@@ -19,7 +21,7 @@ except ImportError:
 
 def _binarize(W):
     """
-    Binarizes a matrix
+    Binarize a matrix.
 
     Parameters
     ----------
@@ -40,7 +42,7 @@ if use_numba:
 
 def degrees_und(W):
     """
-    Computes the degree of each node in `W`
+    Compute the degree of each node in `W`.
 
     Parameters
     ----------
@@ -59,7 +61,7 @@ def degrees_und(W):
 
 def degrees_dir(W):
     """
-    Computes the in degree and out degree of each node in `W`
+    Compute the in degree and out degree of each node in `W`.
 
     Parameters
     ----------
@@ -85,8 +87,7 @@ def degrees_dir(W):
 
 def distance_wei_floyd(D):
     """
-    Computes the shortest path length between all pairs of nodes using
-    Floyd-Warshall algorithm.
+    Compute the all-pairs shortest path length using Floyd-Warshall algorithm.
 
     Parameters
     ----------
@@ -130,7 +131,7 @@ def distance_wei_floyd(D):
 
 def retrieve_shortest_path(s, t, p_mat):
     """
-    Returns the shortest paths between two nodes.
+    Return the shortest paths between two nodes.
 
     Parameters
     ----------
@@ -166,7 +167,7 @@ if use_numba:
 
 def communicability_bin(adjacency, normalize=False):
     """
-    Computes the communicability of pairs of nodes in `adjacency`
+    Compute the communicability of pairs of nodes in `adjacency`.
 
     Parameters
     ----------
@@ -197,7 +198,6 @@ def communicability_bin(adjacency, normalize=False):
            [1.47624622, 2.71828183, 3.19452805],
            [3.19452805, 0.        , 4.19452805]])
     """
-
     if not np.any(np.logical_or(adjacency == 0, adjacency == 1)):
         raise ValueError('Provided adjancecy matrix must be unweighted.')
 
@@ -212,7 +212,7 @@ def communicability_bin(adjacency, normalize=False):
 
 def communicability_wei(adjacency):
     """
-    Computes the communicability of pairs of nodes in `adjacency`
+    Compute the communicability of pairs of nodes in `adjacency`.
 
     Parameters
     ----------
@@ -241,7 +241,6 @@ def communicability_wei(adjacency):
            [0.07810379, 0.        , 0.94712177],
            [0.32263651, 0.        , 0.        ]])
     """
-
     # negative square root of nodal degrees
     row_sum = adjacency.sum(1)
     neg_sqrt = np.power(row_sum, -0.5)
@@ -259,7 +258,7 @@ def communicability_wei(adjacency):
 
 def rich_feeder_peripheral(x, sc, stat='median'):
     """
-    Calculates connectivity values in rich, feeder, and peripheral edges.
+    Calculate connectivity values in rich, feeder, and peripheral edges.
 
     Parameters
     ----------
@@ -286,7 +285,6 @@ def rich_feeder_peripheral(x, sc, stat='median'):
     This code was written by Justine Hansen who promises to fix and even
     optimize the code should any issues arise, provided you let her know.
     """
-
     stats = ['mean', 'median']
     if stat not in stats:
         raise ValueError(f'Provided stat {stat} not valid.\
@@ -342,7 +340,7 @@ def rich_feeder_peripheral(x, sc, stat='median'):
 
 def navigation_wu(nav_dist_mat, sc_mat):
     """
-    Computes network navigation
+    Compute network navigation.
 
     Parameters
     ----------
@@ -383,7 +381,6 @@ def navigation_wu(nav_dist_mat, sc_mat):
     --------
     netneurotools.metrics.get_navigation_path_length
     """
-
     nav_paths = []  # (source, target, distance, hops, path)
     # navigate to the node that is closest to target
     for src in range(len(nav_dist_mat)):
@@ -442,7 +439,7 @@ def navigation_wu(nav_dist_mat, sc_mat):
 
 def get_navigation_path_length(nav_paths, alt_dist_mat):
     """
-    Get navigation path length from navigation results
+    Get navigation path length from navigation results.
 
     Parameters
     ----------
@@ -468,7 +465,6 @@ def get_navigation_path_length(nav_paths, alt_dist_mat):
     --------
     netneurotools.metrics.navigation_wu
     """
-
     nav_path_len = np.zeros_like(alt_dist_mat)
     for nav_item in nav_paths:
         i, j, _, hop, path = nav_item
@@ -483,7 +479,7 @@ def get_navigation_path_length(nav_paths, alt_dist_mat):
 
 def search_information(W, D, has_memory=False):
     """
-    Calculates search information.
+    Calculate search information.
 
     This function implements search information, computes the amount
     of information (measured in bits) that a random walker needs to
@@ -585,7 +581,7 @@ def search_information(W, D, has_memory=False):
 
 def path_transitivity(D):
     """
-    Calculates path transitivity.
+    Calculate path transitivity.
 
     This function implements path transitivity, calculating the density of
     local detours (triangles) that are available along the shortest paths
@@ -615,7 +611,6 @@ def path_transitivity(D):
        by analytic measures of network communication. Proceedings of the
        National Academy of Sciences, 111(2), 833-838.
     """
-
     n = len(D)
     m = np.zeros((n, n))
     T_mat = np.zeros((n, n))
@@ -645,7 +640,7 @@ def path_transitivity(D):
 
 def flow_graph(W, r=None, t=1):
     """
-    Calculates flow graph.
+    Calculate flow graph.
 
     This function implements flow graph, instantiates a continuous
     time random walk on network. Waiting time for walkers at each
@@ -696,7 +691,7 @@ def flow_graph(W, r=None, t=1):
 
 def mean_first_passage_time(W, tol=1e-3):
     """
-    Calculates mean first passage time.
+    Calculate mean first passage time.
 
     The first passage time from i to j is the expected number of steps it takes
     a random walker starting at node i to arrive for the first time at node j.
@@ -747,7 +742,7 @@ def mean_first_passage_time(W, tol=1e-3):
 
 def diffusion_efficiency(W):
     """
-    Calculates diffusion efficiency.
+    Calculate diffusion efficiency.
 
     The diffusion efficiency between nodes i and j is the inverse of the
     mean first passage time from i to j, that is the expected number of
@@ -790,7 +785,7 @@ def diffusion_efficiency(W):
 
 def resource_efficiency_bin(W_bin, lambda_prob=0.5):
     """
-    Calculates resource efficiency and shortest-path probability.
+    Calculate resource efficiency and shortest-path probability.
 
     The resource efficiency between nodes i and j is inversly proportional
     to the amount of resources (i.e. number of particles or messages)
@@ -877,7 +872,7 @@ def resource_efficiency_bin(W_bin, lambda_prob=0.5):
 
 def matching_ind_und(W):
     """
-    Calculates undirected matching index.
+    Calculate undirected matching index.
 
     M0 = MATCHING_IND_UND(CIJ) computes matching index for undirected
     graph specified by adjacency matrix CIJ. Matching index is a measure of

--- a/netneurotools/metrics.py
+++ b/netneurotools/metrics.py
@@ -491,6 +491,9 @@ def search_information(W, D, has_memory=False):
 
     This function is adapted and optimized from the Brain Connectivity Toolbox.
 
+    .. warning::
+       Test before use.
+
     Parameters
     ----------
     W : (N, N) ndarray
@@ -590,6 +593,9 @@ def path_transitivity(D):
 
     This function is adapted and optimized from the Brain Connectivity Toolbox.
 
+    .. warning::
+       Test before use.
+
     Parameters
     ----------
     D : (N, N) ndarray
@@ -646,6 +652,9 @@ def flow_graph(W, r=None, t=1):
     node are distributed as Poisson with rate parameter r.
     This function returns the flow graph at time t.
 
+    .. warning::
+       Test before use.
+
     Parameters
     ----------
     W : (N, N) ndarray
@@ -695,6 +704,9 @@ def mean_first_passage_time(W, tol=1e-3):
     different from `mfpt(j,i)`.
 
     This function is adapted and optimized from the Brain Connectivity Toolbox.
+
+    .. warning::
+       Test before use.
 
     Parameters
     ----------
@@ -746,6 +758,9 @@ def diffusion_efficiency(W):
 
     This function is adapted and optimized from the Brain Connectivity Toolbox.
 
+    .. warning::
+       Test before use.
+
     Parameters
     ----------
     W : (N x N) ndarray
@@ -788,6 +803,9 @@ def resource_efficiency_bin(W_bin, lambda_prob=0.5):
     following (one of) the shortest path(s).
 
     This function is adapted and optimized from the Brain Connectivity Toolbox.
+
+    .. warning::
+       Test before use.
 
     Parameters
     ----------
@@ -868,6 +886,9 @@ def matching_ind_und(W):
 
     This function is adapted and optimized from the Brain Connectivity Toolbox.
 
+    .. warning::
+       Test before use.
+
     Parameters
     ----------
     W : (N x N) ndarray
@@ -881,10 +902,10 @@ def matching_ind_und(W):
     References
     ----------
     .. [1] Goñi, J., Van Den Heuvel, M. P., Avena-Koenigsberger,
-    A., Velez de Mendizabal, N., Betzel, R. F., Griffa, A., ... &
-    Sporns, O. (2014). Resting-brain functional connectivity predicted
-    by analytic measures of network communication. Proceedings of the
-    National Academy of Sciences, 111(2), 833-838.
+       A., Velez de Mendizabal, N., Betzel, R. F., Griffa, A., ... &
+       Sporns, O. (2014). Resting-brain functional connectivity predicted
+       by analytic measures of network communication. Proceedings of the
+       National Academy of Sciences, 111(2), 833-838.
     """
     n = W.shape[0]
     K = np.sum(W, axis=0)

--- a/netneurotools/modularity.py
+++ b/netneurotools/modularity.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Functions for working with network modularity
-"""
+"""Functions for working with network modularity."""
 
 import bct
 import numpy as np
@@ -19,7 +17,7 @@ except ImportError:
 def consensus_modularity(adjacency, gamma=1, B='modularity',
                          repeats=250, null_func=np.mean, seed=None):
     """
-    Finds community assignments from `adjacency` through consensus
+    Find community assignments from `adjacency` through consensus.
 
     Performs `repeats` iterations of community detection on `adjacency` and
     then uses consensus clustering on the resulting community assignments.
@@ -60,7 +58,6 @@ def consensus_modularity(adjacency, gamma=1, B='modularity',
     structure in networks. Chaos: An Interdisciplinary Journal of Nonlinear
     Science, 23(1), 013142.
     """
-
     # generate community partitions `repeat` times
     comms, Q_all = zip(*[bct.community_louvain(adjacency, gamma=gamma, B=B)
                          for i in range(repeats)])
@@ -77,7 +74,7 @@ def consensus_modularity(adjacency, gamma=1, B='modularity',
 
 def _dummyvar(labels):
     """
-    Generates dummy-coded array from provided community assignment `labels`
+    Generate dummy-coded array from provided community assignment `labels`.
 
     Parameters
     ----------
@@ -89,7 +86,6 @@ def _dummyvar(labels):
     ci : (N, G) numpy.ndarray
         Dummy-coded array where 1 indicates that a sample belongs to a group
     """
-
     comms = np.unique(labels)
 
     ci = np.zeros((len(labels), len(comms)))
@@ -101,7 +97,7 @@ def _dummyvar(labels):
 
 def zrand(X, Y):
     """
-    Calculates the z-Rand index of two community assignments
+    Calculate the z-Rand index of two community assignments.
 
     Parameters
     ----------
@@ -119,7 +115,6 @@ def zrand(X, Y):
     (2011). Comparing Community Structure to Characteristics in Online
     Collegiate Social Networks. SIAM Review, 53, 526-543.
     """
-
     if X.ndim > 1 or Y.ndim > 1:
         if X.shape[-1] > 1 or Y.shape[-1] > 1:
             raise ValueError('X and Y must have only one-dimension each. '
@@ -161,7 +156,7 @@ def zrand(X, Y):
 
 def _zrand_partitions(communities):
     """
-    Calculates z-Rand for all pairs of assignments in `communities`
+    Calculate z-Rand for all pairs of assignments in `communities`.
 
     Iterates through every pair of community assignment vectors in
     `communities` and calculates the z-Rand score to assess their similarity.
@@ -176,7 +171,6 @@ def _zrand_partitions(communities):
     all_zrand : array_like
         z-Rand score over all pairs of `R` partitions of community assignments
     """
-
     n_partitions = communities.shape[-1]
     all_zrand = np.zeros(int(n_partitions * (n_partitions - 1) / 2))
 
@@ -196,7 +190,7 @@ if use_numba:
 
 def get_modularity(adjacency, comm, gamma=1):
     """
-    Calculates modularity contribution for each community in `comm`
+    Calculate modularity contribution for each community in `comm`.
 
     Parameters
     ----------
@@ -218,7 +212,6 @@ def get_modularity(adjacency, comm, gamma=1):
     netneurotools.modularity.get_modularity_z
     netneurotools.modularity.get_modularity_sig
     """
-
     adjacency, comm = np.asarray(adjacency), np.asarray(comm)
     s = adjacency.sum()
     B = adjacency - (gamma * np.outer(adjacency.sum(axis=1),
@@ -236,7 +229,7 @@ def get_modularity(adjacency, comm, gamma=1):
 
 def get_modularity_z(adjacency, comm, gamma=1, n_perm=10000, seed=None):
     """
-    Calculates average z-score of community assignments by permutation
+    Calculate average z-score of community assignments by permutation.
 
     Parameters
     ----------
@@ -262,7 +255,6 @@ def get_modularity_z(adjacency, comm, gamma=1, n_perm=10000, seed=None):
     netneurotools.modularity.get_modularity
     netneurotools.modularity.get_modularity_sig
     """
-
     rs = check_random_state(seed)
 
     real_qs = get_modularity(adjacency, comm, gamma)
@@ -283,7 +275,7 @@ def get_modularity_z(adjacency, comm, gamma=1, n_perm=10000, seed=None):
 def get_modularity_sig(adjacency, comm, gamma=1, n_perm=10000, alpha=0.01,
                        seed=None):
     """
-    Calculates signifiance of community assignments in `comm` by permutation
+    Calculate significance of community assignments in `comm` by permutation.
 
     Parameters
     ----------
@@ -296,7 +288,7 @@ def get_modularity_sig(adjacency, comm, gamma=1, n_perm=10000, alpha=0.01,
     n_perm : int, optional
         Number of permutations to test against. Default: 10000
     alpha : (0,1) float, optional
-        Alpha level to assess signifiance. Default: 0.01
+        Alpha level to assess significance. Default: 0.01
     seed : {int, np.random.RandomState instance, None}, optional
         Seed for random number generation. Default: None
 
@@ -310,7 +302,6 @@ def get_modularity_sig(adjacency, comm, gamma=1, n_perm=10000, alpha=0.01,
     netneurotools.modularity.get_modularity_z
     netneurotools.modularity.get_modularity_sig
     """
-
     rs = check_random_state(seed)
 
     real_qs = get_modularity(adjacency, comm, gamma)

--- a/netneurotools/networks.py
+++ b/netneurotools/networks.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Functions for generating group-level networks from individual measurements
-"""
+"""Functions for generating group-level networks from individual measurements."""
 
 import numpy as np
 from scipy.sparse import csgraph
@@ -19,7 +17,7 @@ except ImportError:
 
 def func_consensus(data, n_boot=1000, ci=95, seed=None):
     """
-    Calculates thresholded group consensus functional connectivity graph
+    Calculate thresholded group consensus functional connectivity graph.
 
     This function concatenates all time series in `data` and computes a group
     correlation matrix based on this extended time series. It then generates
@@ -57,7 +55,6 @@ def func_consensus(data, n_boot=1000, ci=95, seed=None):
     competitive spreading dynamics on the human connectome. Neuron, 86(6),
     1518-1529.
     """
-
     # check inputs
     rs = check_random_state(seed)
     if ci > 100 or ci < 0:
@@ -112,7 +109,7 @@ def func_consensus(data, n_boot=1000, ci=95, seed=None):
 
 def _ecdf(data):
     """
-    Estimates empirical cumulative distribution function of `data`
+    Estimate empirical cumulative distribution function of `data`.
 
     Taken directly from StackOverflow. See original answer at
     https://stackoverflow.com/questions/33345780.
@@ -128,7 +125,6 @@ def _ecdf(data):
     quantiles : numpy.darray
         Quantiles
     """
-
     sample = np.atleast_1d(data)
 
     # find the unique values and their corresponding counts
@@ -146,7 +142,7 @@ def _ecdf(data):
 
 def struct_consensus(data, distance, hemiid, weighted=False):
     """
-    Calculates distance-dependent group consensus structural connectivity graph
+    Calculate distance-dependent group consensus structural connectivity graph.
 
     Takes as input a weighted stack of connectivity matrices with dimensions
     (N, N, S) where `N` is the number of nodes and `S` is the number of
@@ -199,7 +195,6 @@ def struct_consensus(data, distance, hemiid, weighted=False):
     dependent consensus thresholds for generating group-representative
     structural brain networks. Network Neuroscience, 1-22.
     """
-
     # confirm input shapes are as expected
     check_consistent_length(data, distance, hemiid)
     try:
@@ -288,7 +283,7 @@ def struct_consensus(data, distance, hemiid, weighted=False):
 
 def binarize_network(network, retain=10, keep_diag=False):
     """
-    Keeps top `retain` % of connections in `network` and binarizes
+    Keep top `retain` % of connections in `network` and binarizes.
 
     Uses the upper triangle for determining connection percentage, which may
     result in disconnected nodes. If this behavior is not desired see
@@ -312,7 +307,6 @@ def binarize_network(network, retain=10, keep_diag=False):
     --------
     netneurotools.networks.threshold_network
     """
-
     if retain < 0 or retain > 100:
         raise ValueError('Value provided for `retain` is outside [0, 100]: {}'
                          .format(retain))
@@ -330,7 +324,7 @@ def binarize_network(network, retain=10, keep_diag=False):
 
 def threshold_network(network, retain=10):
     """
-    Keeps top `retain` % of connections in `network` and binarizes
+    Keep top `retain` % of connections in `network` and binarizes.
 
     Uses a minimum spanning tree to ensure that no nodes are disconnected from
     the resulting thresholded graph
@@ -351,7 +345,6 @@ def threshold_network(network, retain=10):
     --------
     netneurotools.networks.binarize_network
     """
-
     if retain < 0 or retain > 100:
         raise ValueError('Value provided for `retain` must be a percent '
                          'in range [0, 100]. Provided: {}'.format(retain))
@@ -388,7 +381,7 @@ def match_length_degree_distribution(W, D, nbins=10, nswap=1000,
                                      replacement=False, weighted=True,
                                      seed=None):
     """
-    Generates degree- and edge length-preserving surrogate connectomes.
+    Generate degree- and edge length-preserving surrogate connectomes.
 
     Parameters
     ----------
@@ -433,7 +426,6 @@ def match_length_degree_distribution(W, D, nbins=10, nswap=1000,
     long-distance connections in weighted, interareal connectomes. PNAS.
 
     """
-
     rs = check_random_state(seed)
     N = len(W)
     # divide the distances by lengths
@@ -564,7 +556,7 @@ def match_length_degree_distribution(W, D, nbins=10, nswap=1000,
 
 def randmio_und(W, itr):
     """
-    Optimized version of randmio_und
+    Optimized version of randmio_und.
 
     This function randomizes an undirected network, while preserving the
     degree distribution. The function does not preserve the strength
@@ -587,7 +579,6 @@ def randmio_und(W, itr):
     eff : int
         number of actual rewirings carried out
     """  # noqa: E501
-
     W = W.copy()
     n = len(W)
     i, j = np.where(np.triu(W > 0, 1))

--- a/netneurotools/networks.py
+++ b/netneurotools/networks.py
@@ -563,7 +563,7 @@ def match_length_degree_distribution(W, D, nbins=10, nswap=1000,
 
 
 def randmio_und(W, itr):
-    '''
+    """
     Optimized version of randmio_und
 
     This function randomizes an undirected network, while preserving the
@@ -586,7 +586,7 @@ def randmio_und(W, itr):
         Randomized network
     eff : int
         number of actual rewirings carried out
-    '''  # noqa: E501
+    """  # noqa: E501
 
     W = W.copy()
     n = len(W)

--- a/netneurotools/networks.py
+++ b/netneurotools/networks.py
@@ -564,7 +564,7 @@ def match_length_degree_distribution(W, D, nbins=10, nswap=1000,
 
 def randmio_und(W, itr):
     '''
-    randomio_und
+    Optimized version of randmio_und
 
     This function randomizes an undirected network, while preserving the
     degree distribution. The function does not preserve the strength

--- a/netneurotools/plotting.py
+++ b/netneurotools/plotting.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Functions for making pretty plots and whatnot
-"""
+"""Functions for making pretty plots and whatnot."""
 
 import os
 from typing import Iterable
@@ -17,7 +15,7 @@ from .freesurfer import FSIGNORE, _decode_list
 
 def _grid_communities(communities):
     """
-    Generates boundaries of `communities`
+    Generate boundaries of `communities`.
 
     Parameters
     ----------
@@ -29,7 +27,6 @@ def _grid_communities(communities):
     bounds : list
         Boundaries of communities
     """
-
     communities = np.asarray(communities)
     if 0 in communities:
         communities = communities + 1
@@ -48,7 +45,7 @@ def _grid_communities(communities):
 
 def sort_communities(consensus, communities):
     """
-    Sorts `communities` in `consensus` according to strength
+    Sort `communities` in `consensus` according to strength.
 
     Parameters
     ----------
@@ -62,7 +59,6 @@ def sort_communities(consensus, communities):
     inds : np.ndarray
         Index array for sorting `consensus`
     """
-
     communities = np.asarray(communities)
     if 0 in communities:
         communities = communities + 1
@@ -84,7 +80,7 @@ def plot_mod_heatmap(data, communities, *, inds=None, edgecolor='black',
                      square=True, xticklabels=None, yticklabels=None,
                      mask_diagonal=True, **kwargs):
     """
-    Plots `data` as heatmap with borders drawn around `communities`
+    Plot `data` as heatmap with borders drawn around `communities`.
 
     Parameters
     ----------
@@ -126,9 +122,8 @@ def plot_mod_heatmap(data, communities, *, inds=None, edgecolor='black',
     ax : matplotlib.axes.Axes
         Axis object containing plot
     """
-
-    for t, l in zip([xticklabels, yticklabels], [xlabels, ylabels]):
-        if t is not None and l is not None:
+    for t, label in zip([xticklabels, yticklabels], [xlabels, ylabels]):
+        if t is not None and label is not None:
             raise ValueError('Cannot set both {x,y}labels and {x,y}ticklabels')
 
     # get indices for sorting consensus
@@ -216,9 +211,8 @@ def plot_conte69(data, lhlabel, rhlabel, surf='midthickness',
                  colorbar=True, num_labels=4, orientation='horizontal',
                  colorbartitle=None, backgroundcolor=(1, 1, 1),
                  foregroundcolor=(0, 0, 0), **kwargs):
-
     """
-    Plots surface `data` on Conte69 Atlas
+    Plot surface `data` on Conte69 Atlas.
 
     Parameters
     ----------
@@ -262,7 +256,6 @@ def plot_conte69(data, lhlabel, rhlabel, surf='midthickness',
     scene : mayavi.Scene
         Scene object containing plot
     """
-
     return plot_fslr(data, lhlabel, rhlabel, surf_atlas='conte69',
                      surf_type=surf, vmin=vmin, vmax=vmax, colormap=colormap,
                      colorbar=colorbar, num_labels=num_labels,
@@ -277,9 +270,8 @@ def plot_fslr(data, lhlabel, rhlabel, surf_atlas='conte69',
               orientation='horizontal', colorbartitle=None,
               backgroundcolor=(1, 1, 1), foregroundcolor=(0, 0, 0),
               **kwargs):
-
     """
-    Plots surface `data` on a given fsLR32k atlas
+    Plot surface `data` on a given fsLR32k atlas.
 
     Parameters
     ----------
@@ -326,7 +318,6 @@ def plot_fslr(data, lhlabel, rhlabel, surf_atlas='conte69',
     scene : mayavi.Scene
         Scene object containing plot
     """
-
     from .datasets import fetch_conte69, fetch_yerkes19
     try:
         from mayavi import mlab
@@ -398,7 +389,7 @@ def plot_fslr(data, lhlabel, rhlabel, surf_atlas='conte69',
 
 def _get_fs_subjid(subject_id, subjects_dir=None):
     """
-    Gets fsaverage version `subject_id`, fetching if required
+    Get fsaverage version `subject_id`, fetching if required.
 
     Parameters
     ----------
@@ -415,7 +406,6 @@ def _get_fs_subjid(subject_id, subjects_dir=None):
     subjects_dir : str
         Path to subject directory with `subject_id`
     """
-
     from netneurotools.utils import check_fs_subjid
 
     # check for FreeSurfer install w/fsaverage; otherwise, fetch required
@@ -439,7 +429,7 @@ def plot_fsaverage(data, *, lhannot, rhannot, order='lr', mask=None,
                    noplot=None, subject_id='fsaverage', subjects_dir=None,
                    vmin=None, vmax=None, **kwargs):
     """
-    Plots `data` to fsaverage brain using `annot` as parcellation
+    Plot `data` to fsaverage brain using `annot` as parcellation.
 
     Parameters
     ----------
@@ -512,7 +502,6 @@ def plot_fsaverage(data, *, lhannot, rhannot, order='lr', mask=None,
     ...                rhannot=schaefer.rh)  # doctest: +SKIP
 
     """
-
     subject_id, subjects_dir = _get_fs_subjid(subject_id, subjects_dir)
 
     # cast data to float (required for NaNs)
@@ -591,7 +580,7 @@ def plot_fsvertex(data, *, order='lr', surf='pial', views='lat',
                   subject_id='fsaverage', subjects_dir=None, data_kws=None,
                   **kwargs):
     """
-    Plots vertex-wise `data` to fsaverage brain.
+    Plot vertex-wise `data` to fsaverage brain.
 
     Parameters
     ----------
@@ -640,7 +629,6 @@ def plot_fsvertex(data, *, order='lr', surf='pial', views='lat',
     brain : surfer.Brain
         Plotted PySurfer brain
     """
-
     # hold off on imports until
     try:
         from surfer import Brain
@@ -729,7 +717,7 @@ def plot_point_brain(data, coords, views=None, views_orientation='vertical',
                      views_size=(4, 2.4), cbar=False, robust=True, size=50,
                      **kwargs):
     """
-    Plots `data` as a cloud of points in 3D space based on specified `coords`
+    Plot `data` as a cloud of points in 3D space based on specified `coords`.
 
     Parameters
     ----------
@@ -759,7 +747,6 @@ def plot_point_brain(data, coords, views=None, views_orientation='vertical',
     -------
     fig : :class:`matplotlib.figure.Figure`
     """
-
     _views = dict(sagittal=(0, 180), sag=(0, 180),
                   axial=(90, 180), ax=(90, 180),
                   coronal=(0, 90), cor=(0, 90))

--- a/netneurotools/stats.py
+++ b/netneurotools/stats.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Functions for performing statistical preprocessing and analyses
-"""
+"""Functions for performing statistical preprocessing and analyses."""
 
 import warnings
 
@@ -21,7 +19,7 @@ from . import utils
 
 def residualize(X, Y, Xc=None, Yc=None, normalize=True, add_intercept=True):
     """
-    Returns residuals of regression equation from `Y ~ X`
+    Return residuals of regression equation from `Y ~ X`.
 
     Parameters
     ----------
@@ -52,7 +50,6 @@ def residualize(X, Y, Xc=None, Yc=None, normalize=True, add_intercept=True):
     If both `Xc` and `Yc` are provided, these are used to calculate betas which
     are then applied to `X` and `Y`.
     """
-
     if ((Yc is None and Xc is not None) or (Yc is not None and Xc is None)):
         raise ValueError('If processing against a comparative group, you must '
                          'provide both `Xc` and `Yc`.')
@@ -86,7 +83,7 @@ def residualize(X, Y, Xc=None, Yc=None, normalize=True, add_intercept=True):
 
 def get_mad_outliers(data, thresh=3.5):
     """
-    Determines which samples in `data` are outliers
+    Determine which samples in `data` are outliers.
 
     Uses the Median Absolute Deviation for determining whether datapoints are
     outliers
@@ -133,7 +130,6 @@ def get_mad_outliers(data, thresh=3.5):
     >>> outliers
     array([False, False,  True])
     """
-
     data = np.asarray(data)
 
     if data.ndim == 1:
@@ -153,7 +149,7 @@ def get_mad_outliers(data, thresh=3.5):
 
 def permtest_1samp(a, popmean, axis=0, n_perm=1000, seed=0):
     """
-    Non-parametric equivalent of :py:func:`scipy.stats.ttest_1samp`
+    Non-parametric equivalent of :py:func:`scipy.stats.ttest_1samp`.
 
     Generates two-tailed p-value for hypothesis of whether `a` differs from
     `popmean` using permutation tests
@@ -213,7 +209,6 @@ def permtest_1samp(a, popmean, axis=0, n_perm=1000, seed=0):
     >>> stats.permtest_1samp(rvs.T, [5.0, 0.0], axis=1)
     (array([-0.985602  ,  4.94795031]), array([0.51548452, 0.000999  ]))
     """
-
     a, popmean, axis = _chk2_asarray(a, popmean, axis)
     rs = check_random_state(seed)
 
@@ -243,7 +238,7 @@ def permtest_1samp(a, popmean, axis=0, n_perm=1000, seed=0):
 
 def permtest_rel(a, b, axis=0, n_perm=1000, seed=0):
     """
-    Non-parametric equivalent of :py:func:`scipy.stats.ttest_rel`
+    Non-parametric equivalent of :py:func:`scipy.stats.ttest_rel`.
 
     Generates two-tailed p-value for hypothesis of whether related samples `a`
     and `b` differ using permutation tests
@@ -291,7 +286,6 @@ def permtest_rel(a, b, axis=0, n_perm=1000, seed=0):
     >>> stats.permtest_rel(rvs1, rvs3)  # doctest: +SKIP
     (2.40533726097883, 0.000999000999000999)
     """
-
     a, b, axis = _chk2_asarray(a, b, axis)
     rs = check_random_state(seed)
 
@@ -327,7 +321,7 @@ def permtest_rel(a, b, axis=0, n_perm=1000, seed=0):
 
 def permtest_pearsonr(a, b, axis=0, n_perm=1000, resamples=None, seed=0):
     """
-    Non-parametric equivalent of :py:func:`scipy.stats.pearsonr`
+    Non-parametric equivalent of :py:func:`scipy.stats.pearsonr`.
 
     Generates two-tailed p-value for hypothesis of whether samples `a` and `b`
     are correlated using permutation tests
@@ -393,7 +387,6 @@ def permtest_pearsonr(a, b, axis=0, n_perm=1000, resamples=None, seed=0):
     >>> stats.permtest_pearsonr(np.column_stack([x, a]), np.column_stack([y, b]))
     (array([0.50004037, 0.89927523]), array([0.000999, 0.000999]))
     """  # noqa
-
     a, b, axis = _chk2_asarray(a, b, axis)
     rs = check_random_state(seed)
 
@@ -428,7 +421,7 @@ def permtest_pearsonr(a, b, axis=0, n_perm=1000, resamples=None, seed=0):
 
 def efficient_pearsonr(a, b, ddof=1, nan_policy='propagate'):
     """
-    Computes correlation of matching columns in `a` and `b`
+    Compute correlation of matching columns in `a` and `b`.
 
     Parameters
     ----------
@@ -470,7 +463,6 @@ def efficient_pearsonr(a, b, ddof=1, nan_policy='propagate'):
     >>> stats.efficient_pearsonr(np.c_[x1, x2], np.c_[y1, y2])
     (array([0.10032565, 0.79961189]), array([3.20636135e-01, 1.97429944e-23]))
     """
-
     a, b, axis = _chk2_asarray(a, b, 0)
     if len(a) != len(b):
         raise ValueError('Provided arrays do not have same length')
@@ -515,7 +507,7 @@ def efficient_pearsonr(a, b, ddof=1, nan_policy='propagate'):
 
 def _gen_rotation(seed=None):
     """
-    Generates random matrix for rotating spherical coordinates
+    Generate random matrix for rotating spherical coordinates.
 
     Parameters
     ----------
@@ -527,7 +519,6 @@ def _gen_rotation(seed=None):
     rotate_{l,r} : (3, 3) numpy.ndarray
         Rotations for left and right hemisphere coordinates, respectively
     """
-
     rs = check_random_state(seed)
 
     # for reflecting across Y-Z plane
@@ -549,7 +540,7 @@ def gen_spinsamples(coords, hemiid, n_rotate=1000, check_duplicates=True,
                     method='original', exact=False, seed=None, verbose=False,
                     return_cost=False):
     """
-    Returns a resampling array for `coords` obtained from rotations / spins
+    Return a resampling array for `coords` obtained from rotations / spins.
 
     Using the method initially proposed in [ST1]_ (and later modified + updated
     based on findings in [ST2]_ and [ST3]_), this function applies random
@@ -665,7 +656,6 @@ def gen_spinsamples(coords, hemiid, n_rotate=1000, check_duplicates=True,
 
     .. [ST5] https://github.com/spin-test/spin-test
     """
-
     methods = ['original', 'vasa', 'hungarian']
     if method not in methods:
         raise ValueError('Provided method "{}" invalid. Must be one of {}.'
@@ -794,7 +784,7 @@ def gen_spinsamples(coords, hemiid, n_rotate=1000, check_duplicates=True,
 
 def get_dominance_stats(X, y, use_adjusted_r_sq=True, verbose=False):
     """
-    Returns the dominance analysis statistics for multilinear regression.
+    Return the dominance analysis statistics for multilinear regression.
 
     This is a rewritten & simplified version of [DA1]_. It is briefly
     tested against the original package, but still in early stages.
@@ -849,7 +839,6 @@ def get_dominance_stats(X, y, use_adjusted_r_sq=True, verbose=False):
     .. [DA1] https://github.com/dominance-analysis/dominance-analysis
 
     """
-
     # this helps to remove one element from a tuple
     def remove_ret(tpl, elem):
         lst = list(tpl)

--- a/netneurotools/surface.py
+++ b/netneurotools/surface.py
@@ -1,6 +1,4 @@
-"""
-Functions for constructing graphs from surface meshes
-"""
+"""Functions for constructing graphs from surface meshes."""
 
 import numpy as np
 from scipy import sparse
@@ -8,7 +6,7 @@ from scipy import sparse
 
 def _get_edges(faces):
     """
-    Gets set of edges from `faces`
+    Get set of edges from `faces`.
 
     Parameters
     ----------
@@ -20,7 +18,6 @@ def _get_edges(faces):
     edges : (F*3, 2) array_like
         All edges in `faces`
     """
-
     faces = np.asarray(faces)
     edges = np.sort(faces[:, [0, 1, 1, 2, 2, 0]].reshape((-1, 2)), axis=1)
 
@@ -29,7 +26,7 @@ def _get_edges(faces):
 
 def get_direct_edges(vertices, faces):
     """
-    Gets (unique) direct edges and weights in mesh describes by inputs.
+    Get (unique) direct edges and weights in mesh describes by inputs.
 
     Parameters
     ----------
@@ -53,7 +50,7 @@ def get_direct_edges(vertices, faces):
 
 def get_indirect_edges(vertices, faces):
     """
-    Gets indirect edges and weights in mesh described by inputs
+    Get indirect edges and weights in mesh described by inputs.
 
     Indirect edges are between two vertices that participate in faces sharing
     an edge
@@ -150,7 +147,7 @@ def get_indirect_edges(vertices, faces):
 
 def make_surf_graph(vertices, faces, mask=None):
     """
-    Constructs adjacency graph from `surf`.
+    Construct adjacency graph from `surf`.
 
     Parameters
     ----------
@@ -171,7 +168,6 @@ def make_surf_graph(vertices, faces, mask=None):
     ------
     ValueError : inconsistent number of vertices in `mask` and `vertices`
     """
-
     if mask is not None and len(mask) != len(vertices):
         raise ValueError('Supplied `mask` array has different number of '
                          'vertices than supplied `vertices`.')

--- a/netneurotools/tests/test_civet.py
+++ b/netneurotools/tests/test_civet.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-For testing netneurotools.civet functionality
-"""
+"""For testing netneurotools.civet functionality."""
 
 import numpy as np
 import pytest

--- a/netneurotools/tests/test_cluster.py
+++ b/netneurotools/tests/test_cluster.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-For testing netneurotools.cluster functionality
-"""
+"""For testing netneurotools.cluster functionality."""
 
 import bct
 import numpy as np

--- a/netneurotools/tests/test_datasets.py
+++ b/netneurotools/tests/test_datasets.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-For testing netneurotools.datasets functionality
-"""
+"""For testing netneurotools.datasets functionality."""
 
 import os
 

--- a/netneurotools/tests/test_freesurfer.py
+++ b/netneurotools/tests/test_freesurfer.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-For testing netneurotools.freesurfer functionality
-"""
+"""For testing netneurotools.freesurfer functionality."""
 
 import numpy as np
 import pytest

--- a/netneurotools/tests/test_metrics.py
+++ b/netneurotools/tests/test_metrics.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-For testing netneurotools.metrics functionality
-"""
+"""For testing netneurotools.metrics functionality."""
 
 import numpy as np
 import pytest

--- a/netneurotools/tests/test_modularity.py
+++ b/netneurotools/tests/test_modularity.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""For testing netneurotools.modularity functionality."""
 
 import numpy as np
 
@@ -35,8 +36,7 @@ def test_zrand_partitions():
     # make random communities
     comm = rs.choice(range(6), size=(10, 100))
     all_diff = modularity._zrand_partitions(comm)
-    all_same = modularity._zrand_partitions(np.repeat(comm[:, [0]], 10,
-                                                      axis=1))
+    all_same = modularity._zrand_partitions(np.repeat(comm[:, [0]], 10, axis=1))
 
     # partition of labels that are all the same should have higher average
     # zrand and lower stdev zrand

--- a/netneurotools/tests/test_plotting.py
+++ b/netneurotools/tests/test_plotting.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-For testing netneurotools.plotting functionality
-"""
+"""For testing netneurotools.plotting functionality."""
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/netneurotools/tests/test_stats.py
+++ b/netneurotools/tests/test_stats.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-For testing netneurotools.stats functionality
-"""
+"""For testing netneurotools.stats functionality."""
 
 import itertools
 import numpy as np
@@ -106,14 +104,13 @@ def test_gen_rotation():
     # confirm reflection across L/R hemispheres as expected
     # also confirm min/max never exceeds -1/1
     reflected = np.array([[1, -1, -1], [-1, 1, 1], [-1, 1, 1]])
-    for r, l in zip([rout1, rout3], [lout1, lout3]):
+    for r, l in zip([rout1, rout3], [lout1, lout3]):  # noqa: E741
         assert np.allclose(r / l, reflected)
         assert r.max() < 1 and r.min() > -1 and l.max() < 1 and l.min() > -1
 
 
 def _get_sphere_coords(s, t, r=1):
-    """ Gets coordinates at angles `s` and `t` a sphere of radius `r`
-    """
+    """Get coordinates at angles `s` and `t` a sphere of radius `r`."""
     # convert to radians
     rad = np.pi / 180
     s, t = s * rad, t * rad

--- a/netneurotools/tests/test_utils.py
+++ b/netneurotools/tests/test_utils.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-For testing netneurotools.utils functionality
-"""
+"""For testing netneurotools.utils functionality."""
 
 import numpy as np
 import pytest

--- a/netneurotools/utils.py
+++ b/netneurotools/utils.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Miscellaneous functions of various utility
-"""
+"""Miscellaneous functions of various utility."""
 
 import glob
 import os
@@ -15,10 +13,10 @@ from sklearn.utils.validation import check_array
 
 def add_constant(data):
     """
-    Adds a constant (i.e., intercept) term to `data`
+    Add a constant (i.e., intercept) term to `data`.
 
     Parameters
-    -----------
+    ----------
     data : (N, M) array_like
         Samples by features data array
 
@@ -40,14 +38,13 @@ def add_constant(data):
            [0., 0., 0., 0., 0., 1.],
            [0., 0., 0., 0., 0., 1.]])
     """
-
     data = check_array(data, ensure_2d=False)
     return np.column_stack([data, np.ones(len(data))])
 
 
 def get_triu(data, k=1):
     """
-    Returns vectorized version of upper triangle from `data`
+    Return vectorized version of upper triangle from `data`.
 
     Parameters
     ----------
@@ -70,13 +67,12 @@ def get_triu(data, k=1):
     >>> tri
     array([0.5 , 0.25, 0.33])
     """
-
     return data[np.triu_indices(len(data), k=k)].copy()
 
 
 def globpath(*args):
-    """"
-    Joins `args` with :py:func:`os.path.join` and returns sorted glob output
+    """
+    Join `args` with :py:func:`os.path.join` and returns sorted glob output.
 
     Parameters
     ----------
@@ -88,13 +84,12 @@ def globpath(*args):
     files : list
         Sorted list of files
     """
-
     return sorted(glob.glob(os.path.join(*args)))
 
 
 def rescale(data, low=0, high=1):
     """
-    Rescales `data` so it is within [`low`, `high`]
+    Rescale `data` so it is within [`low`, `high`].
 
     Parameters
     ----------
@@ -110,7 +105,6 @@ def rescale(data, low=0, high=1):
     rescaled : np.ndarray
         Rescaled data
     """
-
     data = np.asarray(data)
     rescaled = np.interp(data, (data.min(), data.max()), (low, high))
 
@@ -119,7 +113,7 @@ def rescale(data, low=0, high=1):
 
 def run(cmd, env=None, return_proc=False, quiet=False):
     """
-    Runs `cmd` via shell subprocess with provided environment `env`
+    Run `cmd` via shell subprocess with provided environment `env`.
 
     Parameters
     ----------
@@ -151,8 +145,7 @@ def run(cmd, env=None, return_proc=False, quiet=False):
     0
     >>> p.stdout  # doctest: +SKIP
     'hello world\\n'
-    """
-
+    """  # noqa: D301
     merged_env = os.environ.copy()
     if env is not None:
         if not isinstance(env, dict):
@@ -173,7 +166,7 @@ def run(cmd, env=None, return_proc=False, quiet=False):
 
 def check_fs_subjid(subject_id, subjects_dir=None):
     """
-    Checks that `subject_id` exists in provided FreeSurfer `subjects_dir`
+    Check that `subject_id` exists in provided FreeSurfer `subjects_dir`.
 
     Parameters
     ----------
@@ -194,7 +187,6 @@ def check_fs_subjid(subject_id, subjects_dir=None):
     ------
     FileNotFoundError
     """
-
     # check inputs for subjects_dir and subject_id
     if subjects_dir is None or not os.path.isdir(subjects_dir):
         try:
@@ -215,7 +207,7 @@ def check_fs_subjid(subject_id, subjects_dir=None):
 
 def get_centroids(img, labels=None, image_space=False):
     """
-    Finds centroids of `labels` in `img`
+    Find centroids of `labels` in `img`.
 
     Parameters
     ----------
@@ -234,7 +226,6 @@ def get_centroids(img, labels=None, image_space=False):
     centroids : (N, 3) np.ndarray
         Coordinates of centroids for ROIs in input data
     """
-
     from nilearn._utils import check_niimg_3d
 
     img = check_niimg_3d(img)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,21 @@
 [build-system]
 requires = ["setuptools >= 38.3.0", "wheel", "versioneer-518"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+select = ["E", "F", "W", "D"]
+exclude = [
+    "./netneurotools/_version.py",
+    "./docs/conf.py",
+    "setup.py"
+
+]
+line-length = 88
+
+[tool.ruff.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.per-file-ignores]
+"./netneurotools/tests/*.py" = ["D103"]
+"./examples/*.py" = ["E402", "D"]
+"*/__init__.py" = ["D104", "F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ requires = ["setuptools >= 38.3.0", "wheel", "versioneer-518"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
-select = ["E", "F", "W", "D"]
+select = ["E", "F", "W", "D", "NPY"]
+ignore = ["B905"]
 exclude = [
     "./netneurotools/_version.py",
     "./docs/conf.py",

--- a/resources/generate_atl-cammoun2012_surface.py
+++ b/resources/generate_atl-cammoun2012_surface.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """
+Generate surface annotation files for Cammoun et al., 2012 parcellation.
+
 This script was used to generate the FreeSurfer-style surface annotation files
 for the Cammoun et al., 2012 parcellation provided via `netneurotools`.
 
@@ -44,7 +46,7 @@ HCPCMD = 'wb_command -label-resample {annot} ' \
 def combine_cammoun_500(lhannot, rhannot, subject_id, annot=None,
                         subjects_dir=None, use_cache=True, quiet=False):
     """
-    Combines finest parcellation from Cammoun et al., 2012 for `subject_id`
+    Combine finest parcellation from Cammoun et al., 2012 for `subject_id`.
 
     The parcellations from Cammoun et al., 2012 have five distinct scales; the
     highest resolution parcellation (scale 500) is split into three GCS files
@@ -82,7 +84,6 @@ def combine_cammoun_500(lhannot, rhannot, subject_id, annot=None,
     cammoun500 : list
         List of created annotation files
     """
-
     tolabel = 'mri_annotation2label --subject {subject_id} --hemi {hemi} ' \
               '--outdir {label_dir} --annotation {annot} --sd {subjects_dir}'
     toannot = 'mris_label2annot --sd {subjects_dir} --s {subject_id} ' \

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ exclude =
     */__init__.py
     _version.py
 ignore = W503, E402
-max-line-length = 79
+max-line-length = 88
 
 [tool:pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -18,7 +18,8 @@ if [ -n "${OPTIONAL_DEPENDS}" ]; then
                                     libopengl0 \
                                     libglx0 \
                                     libdbus-1-3 \
-                                    qt5-default
+                                    qtbase5-dev \
+                                    qt5-qmake
         fi
         python -m pip install $DEP || true
     done


### PR DESCRIPTION
### Critical fix
- Replaced `scipy.linalg.expm` with `scipy.sparse.linalg.expm` temporarily, since `scipy.linalg.expm` was reimplemented for scipy>=v1.9.0rc1 (released Jun 24, 2022) and for array size >=400, it *might* give indeterministic results for now, this might influence `netneurotools.metrics.communicability_*` , see https://github.com/scipy/scipy/issues/18086

### New/updated network metrics
Many of them are optimized and now significantly faster than bctpy. However, they are only lightly tested and might contain bugs (especially for edge cases). **Please test with BCT before use and report any bugs.**

network communication
- `search_information()`
- `path_transitivity()`
- `flow_graph()`
- `mean_first_passage_time()`
- `diffusion_efficiency()`
- `resource_efficiency_bin()`
- `matching_ind_und()`

null network
- `randmio_und()`

### Test fixes
Our test run on `ubuntu-latest` so it currently should be 22.04, causing a bunch of bugs
- Removed Python 3.6 because of actions limitation, see https://github.com/actions/setup-python/issues/544
-  Replaced qt5-default with qtbase5-dev and qt5-qmake, see https://stackoverflow.com/questions/74110674/problem-installing-qt5-default-on-ubuntu-22-04

Updated Github Actions file for simpler testing, plotting tests (2 of them) are currently disabled by `importerskip`.

Doctest is probably also skipped at the moment.

One file `standard_mesh_atlases.zip` is offline, switching to Wayback Machine.

### Maintenance
- Major style fix using ruff (not added to tests for now)
- Changed flake8 `max-line-length` to 88
- Changed custom css for docs
- Fixed some settings in docs
- Updated the main README