### PR TITLE
[FIX] Fix deprecation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/netneurotools/datasets/utils.py
+++ b/netneurotools/datasets/utils.py
@@ -3,7 +3,12 @@
 
 import json
 import os
-from pkg_resources import resource_filename
+try:
+    import importlib.resources
+    _importlib_avail = True
+except ImportError:
+    from pkg_resources import resource_filename
+    _importlib_avail = False
 
 
 def _osfify_urls(data):
@@ -36,8 +41,12 @@ def _osfify_urls(data):
 
     return data
 
+if _importlib_avail:
+    osf = importlib.resources.files("netneurotools") / "data/osf.json"
+else:
+    osf = resource_filename('netneurotools', 'data/osf.json')
 
-with open(resource_filename('netneurotools', 'data/osf.json')) as src:
+with open(osf) as src:
     OSF_RESOURCES = _osfify_urls(json.load(src))
 
 

--- a/netneurotools/datasets/utils.py
+++ b/netneurotools/datasets/utils.py
@@ -48,12 +48,6 @@ if _importlib_avail:
 else:
     osf = resource_filename('netneurotools', 'data/osf.json')
 
-
-if _importlib_avail:
-    osf = importlib.resources.files("netneurotools") / "data/osf.json"
-else:
-    osf = resource_filename('netneurotools', 'data/osf.json')
-
 with open(osf) as src:
     OSF_RESOURCES = _osfify_urls(json.load(src))
 

--- a/netneurotools/datasets/utils.py
+++ b/netneurotools/datasets/utils.py
@@ -42,6 +42,11 @@ def _osfify_urls(data):
 
     return data
 
+if _importlib_avail:
+    osf = importlib.resources.files("netneurotools") / "data/osf.json"
+else:
+    osf = resource_filename('netneurotools', 'data/osf.json')
+
 
 if _importlib_avail:
     osf = importlib.resources.files("netneurotools") / "data/osf.json"

--- a/netneurotools/datasets/utils.py
+++ b/netneurotools/datasets/utils.py
@@ -3,10 +3,11 @@
 
 import json
 import os
-try:
-    import importlib.resources
+import importlib.resources
+
+if getattr(importlib.resources, 'files', None) is not None:
     _importlib_avail = True
-except ImportError:
+else:
     from pkg_resources import resource_filename
     _importlib_avail = False
 

--- a/netneurotools/datasets/utils.py
+++ b/netneurotools/datasets/utils.py
@@ -42,6 +42,7 @@ def _osfify_urls(data):
 
     return data
 
+
 if _importlib_avail:
     osf = importlib.resources.files("netneurotools") / "data/osf.json"
 else:


### PR DESCRIPTION
Since `pkg_resources ` is going to be removed in Python 3.12, replacing it with `importlib.resources.files`. Currently it is not a perfect solution because `importlib.resources` is also undergoing substantial changes across version.