### PR TITLE
fix: resolve import error when importing _fetch_files from nilearn

### DIFF
--- a/netneurotools/datasets/fetchers.py
+++ b/netneurotools/datasets/fetchers.py
@@ -7,7 +7,11 @@ import json
 import os.path as op
 import warnings
 
-from nilearn.datasets.utils import _fetch_files
+try:
+    from nilearn.datasets.utils import _fetch_files
+except ImportError:
+    from nilearn.datasets._utils import fetch_files as _fetch_files
+
 import numpy as np
 from sklearn.utils import Bunch
 


### PR DESCRIPTION
Hi there,

It seems like netneurotools is importing some private utilities from nilearn like `_fetch_files`.
Recently, nilearn made some changes to its structure and moved this utility function from `nilearn.datasets.utils` into a private `nilearn.datasets._utils` module (the function was also renamed `fetch_files` since it is now within a private module). There was no deprecation warnings as this is not part of the nilearn public API.

This is impacting the Clinica project on which I am working (because it depends on Brainstats which depends on netneurotools).

This PR proposes to fix the broken import in a backward compatible way using a simple try/except.

If this solution is acceptable, could you make a patch release soonish such that we can fix this dependency issue on our side.

Many thanks !