### PR TITLE
[MNT] Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,11 @@ test = [
 requires = ["setuptools", "versioneer[toml]"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+include = [
+  "netneurotools",
+  "netneurotools.*"
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "netneurotools.__version__"}


### PR DESCRIPTION
Addressing #141, updating `pyproject.toml` so that `docs`, `examples` and `resources` folders will not appear in the top-level of `site-packages`.