### PR TITLE
[ENH] Add fetch_bazinet_assortavity + a few minor changes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -62,6 +62,7 @@ To download project-related data
    fetch_shafiei_megfmrimapping
    fetch_shafiei_megdynamics
    fetch_suarez_mami
+   fetch_bazinet_assortativity
    fetch_famous_gmat
    fetch_neurosynth
 

--- a/netneurotools/datasets/__init__.py
+++ b/netneurotools/datasets/__init__.py
@@ -26,7 +26,7 @@ from .fetch_project import (
     fetch_hansen_manynetworks, fetch_hansen_receptors,
     fetch_hansen_genescognition, fetch_hansen_brainstemfc,
     fetch_shafiei_megfmrimapping, fetch_shafiei_megdynamics,
-    fetch_suarez_mami,
+    fetch_suarez_mami, fetch_bazinet_assortativity,
     # example data
     fetch_famous_gmat,
     # resources

--- a/netneurotools/datasets/fetch_project.py
+++ b/netneurotools/datasets/fetch_project.py
@@ -137,7 +137,11 @@ def fetch_hansen_manynetworks(force=False, data_dir=None, verbose=1):
 
     References
     ----------
-    .. [1]
+    .. [1] Justine Y Hansen, Golia Shafiei, Katharina Voigt, Emma X Liang,
+        Sylvia ML Cox, Marco Leyton, Sharna D Jamadar, and Bratislav Misic.
+        Integrating multimodal and multiscale connectivity blueprints of the
+        human cerebral cortex in health and disease. PLoS biology,
+        21(9):e3002314, 2023.
     """
     dataset_name = "ds-hansen_manynetworks"
     _get_reference_info(dataset_name, verbose=verbose)
@@ -418,6 +422,46 @@ def fetch_suarez_mami(force=False, data_dir=None, verbose=1):
         mammalian class. Nature Neuroscience, 23(7):805\u2013808, 2020.
     """
     dataset_name = "ds-suarez_mami"
+    _get_reference_info(dataset_name, verbose=verbose)
+
+    fetched = fetch_file(dataset_name, force=force, data_dir=data_dir, verbose=verbose)
+
+    return fetched
+
+
+def fetch_bazinet_assortativity(force=False, data_dir=None, verbose=1):
+    """
+    Download files from Bazinet et al., 2023, Nature Communications.
+
+    This dataset contains
+
+    If you used this data, please cite [1]_.
+
+    Returns
+    -------
+    filenames : :class:`sklearn.utils.Bunch`
+        Dictionary-like object with fetched data.
+
+    Other Parameters
+    ----------------
+    force : bool, optional
+        If True, will overwrite existing dataset. Default: False
+    data_dir : str, optional
+        Path to use as data directory. If not specified, will check for
+        environmental variable 'NNT_DATA'; if that is not set, will use
+        `~/nnt-data` instead. Default: None
+    verbose : int, optional
+        Modifies verbosity of download, where higher numbers mean more updates.
+        Default: 1
+
+    References
+    ----------
+    .. [1] Vincent Bazinet, Justine Y Hansen, Reinder Vos de Wael,
+        Boris C Bernhardt, Martijn P van den Heuvel, and Bratislav Misic.
+        Assortative mixing in micro-architecturally annotated brain
+        connectomes. Nature Communications, 14(1):2850, 2023."
+    """
+    dataset_name = "ds-bazinet_assortativity"
     _get_reference_info(dataset_name, verbose=verbose)
 
     fetched = fetch_file(dataset_name, force=force, data_dir=data_dir, verbose=verbose)

--- a/netneurotools/datasets/netneurotools.bib
+++ b/netneurotools/datasets/netneurotools.bib
@@ -336,3 +336,14 @@
   year={2020},
   publisher={Nature Publishing Group US New York}
 }
+
+@article{bazinet2023assortative,
+  title={Assortative mixing in micro-architecturally annotated brain connectomes},
+  author={Bazinet, Vincent and Hansen, Justine Y and Vos de Wael, Reinder and Bernhardt, Boris C and van den Heuvel, Martijn P and Misic, Bratislav},
+  journal={Nature Communications},
+  volume={14},
+  number={1},
+  pages={2850},
+  year={2023},
+  publisher={Nature Publishing Group UK London}
+}

--- a/netneurotools/datasets/references.json
+++ b/netneurotools/datasets/references.json
@@ -324,5 +324,13 @@
                 "bibkey": "assaf2020conservation"
             }
         ]
+    },
+    "ds-bazinet_assortativity": {
+        "primary": [
+            {
+                "citation": "Vincent Bazinet, Justine Y Hansen, Reinder Vos de Wael, Boris C Bernhardt, Martijn P van den Heuvel, and Bratislav Misic. Assortative mixing in micro-architecturally annotated brain connectomes. Nature Communications, 14(1):2850, 2023.",
+                "bibkey": "bazinet2023assortative"
+            }
+        ]
     }
 }

--- a/netneurotools/interface/surf_parc.py
+++ b/netneurotools/interface/surf_parc.py
@@ -224,7 +224,7 @@ def _parcels_to_vertices_single_hemi(
         raise RuntimeWarning(f"Keys are not ordered: {keys}, {labels}")
 
     projected = np.full(
-        (vertices.shape[0],) + parc_data.shape[1:], fill, dtype=parc_data.dtype
+        (vertices.shape[0],) + parc_data.shape[1:], fill, dtype=np.float64
     )
     for i_idx, idx in enumerate(keys):
         found = vertices == idx

--- a/netneurotools/modularity/modules.py
+++ b/netneurotools/modularity/modules.py
@@ -619,7 +619,7 @@ def get_modularity_z(adjacency, comm, gamma=1, n_perm=10000, seed=None):
 
     # avoid instances where dist.std(1) == 0
     std = simu_qs.std(axis=1)
-    if std == 0:
+    if np.any(std == 0):
         return np.mean(real_qs - simu_qs.mean(axis=1))
     else:
         return np.mean((real_qs - simu_qs.mean(axis=1)) / std)


### PR DESCRIPTION
This Pull Request adds a `fetch_bazinet_assortativity` function. 

It also incorporates a few minor changes:

- It adds a reference to the docstring of the `fetch_hansen_manynetworks` function.
- It fixes a `ValueError` in `get_modularity_z`, fixing issue [#148](https://github.com/netneurolab/netneurotools/issues/148). 
- It fixes an issue in `parcels_to_vertices` where np.nan values were converted to the lowest possible integer values when the type of the parcellated data was `int`