### PR TITLE
Add minimum dependencies test job and update installation documentation

### DIFF
--- a/.github/workflows/tests-basic.yml
+++ b/.github/workflows/tests-basic.yml
@@ -92,7 +92,7 @@ jobs:
               print(mod.__name__, mod.__version__)
           "
       - name: Run tests
-        run: pytest --doctest-modules --junitxml=junit/test-results-min-deps.xml --verbose -m "not (fetcher or pyvista or pysurfer)" netneurotools
+        run: pytest --doctest-modules --junitxml=junit/test-results-min-deps.xml --verbose -m "not (fetcher or pyvista or pysurfer or numba)" netneurotools
       - name: Upload pytest test results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tests-basic.yml
+++ b/.github/workflows/tests-basic.yml
@@ -59,3 +59,42 @@ jobs:
         with:
           name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}
           path: junit/test-results.xml
+
+  run_min_deps_tests:
+    needs: check_style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.9'
+      - name: Install netneurotools with minimum dependency versions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install '.[test]'
+          python -m pip install \
+            "numpy==1.22.0" \
+            "scipy==1.8.0" \
+            "scikit-learn==1.0.0" \
+            "networkx==2.8" \
+            "nibabel==3.2.0" \
+            "nilearn==0.9.0" \
+            "matplotlib==3.5.0"
+      - name: Print dependency versions
+        run: |
+          python -c "
+          import numpy, scipy, sklearn, networkx, nibabel, nilearn, matplotlib
+          for mod in [numpy, scipy, sklearn, networkx, nibabel, nilearn, matplotlib]:
+              print(mod.__name__, mod.__version__)
+          "
+      - name: Run tests
+        run: pytest --doctest-modules --junitxml=junit/test-results-min-deps.xml --verbose -m "not (fetcher or pyvista or pysurfer)" netneurotools
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results-min-deps
+          path: junit/test-results-min-deps.xml

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,6 +23,22 @@ Alternatively, you can install ``netneurotools`` directly from PyPi with:
     pip install netneurotools
 
 
+Minimum tested dependency versions
+----------------------------------
+
+In continuous integration, we also run a minimum-dependencies test job on
+Python 3.9 to check compatibility with older supported package versions.
+The currently tested minimum versions are:
+
+- ``numpy==1.22.0``
+- ``scipy==1.8.0``
+- ``scikit-learn==1.0.0``
+- ``networkx==2.8``
+- ``nibabel==3.2.0``
+- ``nilearn==0.9.0``
+- ``matplotlib==3.5.0``
+
+
 Optional dependencies for surface plotting
 ------------------------------------------
 

--- a/netneurotools/metrics/bct.py
+++ b/netneurotools/metrics/bct.py
@@ -836,12 +836,10 @@ def assortativity_und(x, W, use_numba=False):
     is defined as:
 
     .. math::
-        \begin{align}
         r & = \sum_{ij} \frac{a_{ij}}{2m} \tilde{x}_i \tilde{x}_j \\
           & = \sum_{ij} \frac{a_{ij}}{2m}
           (\frac{x_i-\bar{\mathbf{x}}}{\sigma_{\mathbf{x}}})
           (\frac{x_j-\bar{\mathbf{x}}}{\sigma_{\mathbf{x}}})
-        \end{align}
 
     where :math:`a_{ij}` is the weight of the connection between nodes :math:`i`
     and :math:`j`, :math:`2m` is the total weight of the network.
@@ -849,11 +847,9 @@ def assortativity_und(x, W, use_numba=False):
     standard deviation of the annotation, defined as:
 
     .. math::
-        \begin{align}
         \bar{\mathbf{x}} & = \frac{1}{2m} \sum_i k_i x_i \\
         \sigma_{\mathbf{x}} & = \sqrt{\frac{1}{2m}
         \sum_i k_i (x_i - \bar{\mathbf{x}})^2}
-        \end{align}
 
     in which :math:`k_i` is the sum of the weights of the connections to node :math:`i`.
 
@@ -947,13 +943,11 @@ def assortativity_dir(x, W, use_numba=False):
 
     .. math::
 
-        \begin{align}
         r & = \sum_{ij} \frac{a_{ij}}{m}
         \tilde{x}_i^{\text{out}} \tilde{x}_j^{\text{in}} \\
         & = \sum_{ij} \frac{a_{ij}}{m}
         (\frac{x_i-\bar{\mathbf{x}}^{\text{out}}}{\sigma_{\mathbf{x}}^{\text{out}}})
         (\frac{x_j-\bar{\mathbf{x}}^{\text{in}}}{\sigma_{\mathbf{x}}^{\text{in}}})
-        \end{align}
 
     where :math:`a_{ij}` is the weight of the directed connection from node
     :math:`i` to node :math:`j`, and :math:`m` is the total weight of the
@@ -965,14 +959,12 @@ def assortativity_dir(x, W, use_numba=False):
 
     .. math::
 
-        \begin{align}
         \bar{\mathbf{x}}^{\text{in}} & = \frac{1}{m} \sum_i k_i^{\text{in}} x_i \\
         \bar{\mathbf{x}}^{\text{out}} & = \frac{1}{m} \sum_i k_i^{\text{out}} x_i \\
         \sigma_{\mathbf{x}}^{\text{in}} & = \sqrt{\frac{1}{m}
         \sum_i k_i^{\text{in}} (x_i - \bar{\mathbf{x}}^{\text{in}})^2} \\
         \sigma_{\mathbf{x}}^{\text{out}} & = \sqrt{\frac{1}{m}
         \sum_i k_i^{\text{out}} (x_i - \bar{\mathbf{x}}^{\text{out}})^2}
-        \end{align}
 
     in which :math:`k_i^{\text{in}}` is the sum of incoming weights to node
     :math:`i` and :math:`k_i^{\text{out}}` is the sum of outgoing weights from

--- a/netneurotools/spatial/tests/test_spatialstats.py
+++ b/netneurotools/spatial/tests/test_spatialstats.py
@@ -60,6 +60,20 @@ def test_morans_i(generate_test_data):
     """Test Moran's I calculation."""
     annot_1, _, weight, expected = generate_test_data
     assert np.isclose(morans_i(annot_1, weight, use_numba=False), expected)
+
+
+@pytest.mark.numba
+@pytest.mark.parametrize(
+    "generate_test_data",
+    [
+        pytest.param({"n": n, "which": "morans_i"}, id=f"morans_i-{n}")
+        for n in [3, 4]
+    ],
+    indirect=True,
+)
+def test_morans_i_numba(generate_test_data):
+    """Test Moran's I calculation with numba."""
+    annot_1, _, weight, expected = generate_test_data
     assert np.isclose(morans_i(annot_1, weight, use_numba=True), expected)
 
 
@@ -89,6 +103,20 @@ def test_gearys_c(generate_test_data):
     """Test Geary's C calculation."""
     annot_1, _, weight, expected = generate_test_data
     assert np.isclose(gearys_c(annot_1, weight, use_numba=False), expected)
+
+
+@pytest.mark.numba
+@pytest.mark.parametrize(
+    "generate_test_data",
+    [
+        pytest.param({"n": n, "which": "gearys_c"}, id=f"gearys_c-{n}")
+        for n in [3, 4]
+    ],
+    indirect=True,
+)
+def test_gearys_c_numba(generate_test_data):
+    """Test Geary's C calculation with numba."""
+    annot_1, _, weight, expected = generate_test_data
     assert np.isclose(gearys_c(annot_1, weight, use_numba=True), expected)
 
 
@@ -118,6 +146,20 @@ def test_lees_l(generate_test_data):
     """Test Lee's L calculation."""
     annot_1, annot_2, weight, expected = generate_test_data
     assert np.isclose(lees_l(annot_1, annot_2, weight, use_numba=False), expected)
+
+
+@pytest.mark.numba
+@pytest.mark.parametrize(
+    "generate_test_data",
+    [
+        pytest.param({"n": n, "which": "lees_l"}, id=f"lees_l-{n}")
+        for n in [3, 4]
+    ],
+    indirect=True,
+)
+def test_lees_l_numba(generate_test_data):
+    """Test Lee's L calculation with numba."""
+    annot_1, annot_2, weight, expected = generate_test_data
     assert np.isclose(lees_l(annot_1, annot_2, weight, use_numba=True), expected)
 
 

--- a/netneurotools/stats/tests/test_correlation.py
+++ b/netneurotools/stats/tests/test_correlation.py
@@ -45,11 +45,27 @@ def test_efficient_pearsonr_errors():
 def test_weighted_pearsonr(x, y, w, expected):
     """Test weighted_pearsonr function."""
     assert np.allclose(
-        stats.weighted_pearsonr(x, y, w, use_numba=True),
+        stats.weighted_pearsonr(x, y, w, use_numba=False),
         expected,
     )
+
+
+@pytest.mark.numba
+@pytest.mark.parametrize(
+    "x, y, w, expected",
+    [
+        (
+            np.array([3, 5, 6, 8, 3, 2, 6]),
+            np.array([3, 5, 2, 8, 3, 3, 6]),
+            np.array([7, 3, 3, 2, 4, 5, 7]),
+            0.7356763090950997,
+        )
+    ],
+)
+def test_weighted_pearsonr_numba(x, y, w, expected):
+    """Test weighted_pearsonr function with numba."""
     assert np.allclose(
-        stats.weighted_pearsonr(x, y, w, use_numba=False),
+        stats.weighted_pearsonr(x, y, w, use_numba=True),
         expected,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ convention = "numpy"
 addopts = "--strict-markers --pyargs"
 markers = [
   "fetcher: mark test to fetch data from the internet",
+  "numba: mark test that requires numba",
   "pyvista: mark test that requires pyvista",
   "pysurfer: mark test that requires pysurfer"
 ]


### PR DESCRIPTION
This pull request adds continuous integration (CI) testing for the minimum supported dependency versions and documents these versions in the installation guide. Additionally, it makes minor improvements to the documentation of mathematical formulas in the `netneurotools/metrics/bct.py` module.

**Continuous Integration and Documentation Updates:**

* Added a new CI job (`run_min_deps_tests`) to `.github/workflows/tests-basic.yml` to test `netneurotools` with the minimum supported versions of key dependencies on Python 3.9. This ensures compatibility with older package versions.
* Updated `docs/installation.rst` to include a section listing the minimum tested versions of dependencies, reflecting the versions used in CI.

**Documentation Improvements:**

* Cleaned up the math formula documentation in `assortativity_und` and `assortativity_dir` by removing unnecessary LaTeX `align` environments, making the docstrings simpler and less error-prone. [[1]](diffhunk://#diff-9abb69a947f20fedd8cb535baaac9c086fd7730aa166484d1bec6b3604840a77L839-L856) [[2]](diffhunk://#diff-9abb69a947f20fedd8cb535baaac9c086fd7730aa166484d1bec6b3604840a77L950-L956) [[3]](diffhunk://#diff-9abb69a947f20fedd8cb535baaac9c086fd7730aa166484d1bec6b3604840a77L968-L975)