### PR TITLE
[FIX] Allow path objects in `plot_fsaverage` + fix bug in `parcels_to_vertices`

### DIFF
--- a/netneurotools/interface/surf_parc.py
+++ b/netneurotools/interface/surf_parc.py
@@ -316,7 +316,7 @@ def parcels_to_vertices(
                 raise ValueError("Data length mismatch")
             # Split concatenated array into left and right hemispheres
             parc_data = (parc_data[:len(parc_keys[0])],
-                         parc_data[len(parc_keys[1]):])
+                         parc_data[len(parc_keys[0]):])
 
         projected_lh, keys_lh, labels_lh = _parcels_to_vertices_single_hemi(
             parc_data[0],

--- a/netneurotools/plotting/pysurfer_plotters.py
+++ b/netneurotools/plotting/pysurfer_plotters.py
@@ -238,6 +238,14 @@ def plot_fsaverage(data, *, lhannot, rhannot, order='lr', mask=None,
     brain : surfer.Brain
         Plotted PySurfer brain
 
+    Notes
+    -----
+    This function relies on PySurfer, which itself depends on Mayavi and VTK.
+    These dependencies can be difficult to install and maintain. For this
+    reason, we recommend using alternative plotting functions that rely on
+    PyVista instead (e.g., `pv_plot_parcellated_data` and
+    `pv_plot_surface`).
+
     Examples
     --------
     >>> import numpy as np
@@ -298,7 +306,7 @@ def plot_fsaverage(data, *, lhannot, rhannot, order='lr', mask=None,
     vtx_data = []
     for annot, hemi in zip((lhannot, rhannot), ('lh', 'rh')):
         # loads annotation data for hemisphere, including vertex `labels`!
-        if not annot.startswith(os.path.abspath(os.sep)):
+        if not os.path.isabs(annot):
             annot = os.path.join(subjects_dir, subject_id, 'label', annot)
         labels, _, names = nib.freesurfer.read_annot(annot)
         names = _decode_list(names)

--- a/netneurotools/plotting/pysurfer_plotters.py
+++ b/netneurotools/plotting/pysurfer_plotters.py
@@ -199,13 +199,13 @@ def plot_fsaverage(data, *, lhannot, rhannot, order='lr', mask=None,
     ----------
     data : (N,) array_like
         Data for `N` parcels as defined in `annot`
-    lhannot : str
+    lhannot : path-like
         Filepath to .annot file containing labels to parcels on the left
-        hemisphere. If a full path is not provided the file is assumed to
+        hemisphere. If an absolute path is not provided the file is assumed to
         exist inside the `subjects_dir`/`subject`/label directory.
-    rhannot : str
+    rhannot : path-like
         Filepath to .annot file containing labels to parcels on the right
-        hemisphere. If a full path is not provided the file is assumed to
+        hemisphere. If an absolute path is not provided the file is assumed to
         exist inside the `subjects_dir`/`subject`/label directory.
     order : str, optional
         Order of the hemispheres in the data vector (either 'LR' or 'RL').


### PR DESCRIPTION
The function `plot_fsaverage` required the user to input a `str` for `lhannot` and `rhannot`. The user can now input a path object (e.g. from pathlib). 

This PR also fixes a bug in `parcels_to_vertices`.

I also added a note in the dosctring recommending users to use the Pyvista plotting functions instead .