### PR TITLE
Fix return statement in MMP case for atlas selection

### DIFF
--- a/netneurotools/plotting/pyvista_plotters.py
+++ b/netneurotools/plotting/pyvista_plotters.py
@@ -893,7 +893,7 @@ def _resolve_parcellation(parcellation, template, hemi="both"):
     elif parc_str == 'mmpall':
         atlas = fetch_mmpall(version=template)
         atlas = relabel_gifti((atlas[0], atlas[1]))
-        return _select_hemi(atlas[key])
+        return _select_hemi(atlas)
 
     # else, the `parcellation` string is a normal path (presumably)
     return parcellation


### PR DESCRIPTION
This pull request makes a small but important fix to the `_select_hemi` function in `pyvista_plotters.py`. The change corrects how the `atlas` variable is passed to `_select_hemi` when the `parc_str` is `'mmpall'`, ensuring the function receives the expected argument type.

* Bug fix:
  * [`netneurotools/plotting/pyvista_plotters.py`](diffhunk://#diff-fc777acd6a68141e34b84a7d95ca5fdafe5cc785be5a69b66b54d33bcc2555a6L896-R896): Updated the call to `_select_hemi` to pass the entire `atlas` object instead of just `atlas[key]`, which resolves a potential error in hemisphere selection for the `'mmpall'` parcellation.